### PR TITLE
[q2GwOelX] Courses Integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "scripts": {
     "build": "fedx-scripts webpack",
+    "build:tailwind": "node scripts/build-tailwind.mjs",
     "i18n_extract": "fedx-scripts formatjs extract",
     "lint": "fedx-scripts eslint --ext .jsx,.js src/",
     "lint-fix": "fedx-scripts eslint --fix --ext .jsx,.js src/",

--- a/scripts/build-tailwind.mjs
+++ b/scripts/build-tailwind.mjs
@@ -1,0 +1,76 @@
+/* eslint-disable no-console, no-restricted-syntax, no-continue, import/no-unresolved */
+/**
+ * Regenerate src/sass/_tailwind.scss from src/sass/_input.scss.
+ *
+ * This project checks the compiled Tailwind output into the repo instead of
+ * running Tailwind inside the webpack build, so a `tw:` class that no source
+ * file used before will not exist in the CSS until this is re-run. Symptom:
+ * markup looks completely unstyled even though the class names are right.
+ *
+ * Run it after adding or changing any `tw:` class:
+ *
+ *     npm run build:tailwind
+ *
+ * There is no @tailwindcss/cli installed, so this drives the compiler API and
+ * scans the source for candidates itself.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { compile } from 'tailwindcss';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SASS_DIR = path.join(ROOT, 'src/sass');
+const TW_DIR = path.join(ROOT, 'node_modules/tailwindcss');
+const OUT = path.join(SASS_DIR, '_tailwind.scss');
+
+const loadStylesheet = async (id, base) => {
+  let file;
+  if (id === 'tailwindcss') {
+    file = path.join(TW_DIR, 'index.css');
+  } else if (id.startsWith('tailwindcss/')) {
+    file = path.join(TW_DIR, id.slice('tailwindcss/'.length));
+  } else {
+    file = path.resolve(base, id);
+  }
+  if (!path.extname(file)) { file += '.css'; }
+  return { path: file, base: path.dirname(file), content: fs.readFileSync(file, 'utf8') };
+};
+
+const loadModule = async (id) => {
+  throw new Error(`JS plugins are not supported by this script (asked for ${id})`);
+};
+
+const walk = (dir, out = []) => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (['node_modules', '__snapshots__'].includes(entry.name)) { continue; }
+      walk(full, out);
+    } else if (/\.(jsx?|tsx?|html)$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+};
+
+// Deliberately does not break on parens or commas: arbitrary values such as
+// shadow-[0_1px_3px_rgba(0,0,0,0.08)] contain both and must stay whole.
+const CANDIDATE_RE = /[^\s"'`{}<>=;]*tw:[^\s"'`{}<>=;]*/g;
+
+const candidates = new Set();
+for (const file of walk(path.join(ROOT, 'src'))) {
+  for (const token of (fs.readFileSync(file, 'utf8').match(CANDIDATE_RE) || [])) {
+    candidates.add(token);
+  }
+}
+
+const compiler = await compile(fs.readFileSync(path.join(SASS_DIR, '_input.scss'), 'utf8'), {
+  base: SASS_DIR,
+  loadStylesheet,
+  loadModule,
+});
+
+fs.writeFileSync(OUT, compiler.build([...candidates]));
+console.log(`Wrote ${path.relative(ROOT, OUT)} from ${candidates.size} candidates.`);

--- a/src/assets/course-placeholder.svg
+++ b/src/assets/course-placeholder.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" role="img" aria-label="Course">
+  <defs>
+    <linearGradient id="cp-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6255A1"/>
+      <stop offset="1" stop-color="#4EA1C9"/>
+    </linearGradient>
+    <linearGradient id="cp-sheen" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.14"/>
+      <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="400" height="300" fill="url(#cp-bg)"/>
+  <path d="M0 0 H400 V150 L0 240 Z" fill="url(#cp-sheen)"/>
+
+  <!-- Mortarboard, drawn body-first so the board sits on top of it -->
+  <g fill="#ffffff" opacity="0.82">
+    <path d="M152 138 L152 176 Q200 198 248 176 L248 138 Z" opacity="0.55"/>
+    <path d="M200 96 L288 132 L200 168 L112 132 Z"/>
+  </g>
+  <g stroke="#ffffff" stroke-opacity="0.82" fill="none" stroke-linecap="round">
+    <path d="M288 132 L288 172" stroke-width="6"/>
+  </g>
+  <circle cx="288" cy="182" r="9" fill="#ffffff" opacity="0.82"/>
+</svg>

--- a/src/components/CourseCard/__snapshots__/index.test.jsx.snap
+++ b/src/components/CourseCard/__snapshots__/index.test.jsx.snap
@@ -2,136 +2,141 @@
 
 exports[`CourseCard matches snapshot with required props 1`] = `
 <DocumentFragment>
-  <div
-    class="tw:bg-white tw:shadow-md tw:rounded-lg tw:overflow-hidden"
+  <a
+    class="tw:block tw:no-underline tw:bg-white tw:rounded-[12px] tw:overflow-hidden tw:shadow-[0_1px_3px_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.06)] tw:hover:shadow-[0_4px_12px_rgba(0,0,0,0.12)] tw:hover:-translate-y-0.5 tw:transition tw:duration-200"
+    href="#"
   >
     <div
-      class="tw:relative tw:w-full tw:h-60"
+      class="tw:relative tw:w-full tw:h-[170px] tw:overflow-hidden"
     >
-      <div
-        class="tw:absolute tw:top-3 tw:left-3 tw:bg-[#69AF79] tw:text-white tw:rounded-full tw:w-10 tw:h-10 tw:flex tw:items-center tw:justify-center tw:text-sm tw:font-bold tw-shadow-lg tw:z-10"
-      >
-        $28
-      </div>
       <img
         alt="Test Course"
-        class="tw:w-full tw:h-full tw:object-cover"
+        class="tw:w-full tw:h-full tw:object-cover tw:object-center"
         src="https://example.com/image.png"
+        style="clip-path: polygon(0 0, 100% 0, 100% 60%, 0 100%);"
       />
-      <div
-        class="tw:absolute tw:inset-0 tw:bg-[#727175] tw:opacity-40"
-        style="clip-path: polygon(0 0, 100% 0px, 100% 65%, 70% 100%, 100% 65%, 0px 105%);"
-      />
+      <span
+        class="tw:absolute tw:top-3 tw:left-3 tw:z-[2] tw:px-3 tw:py-1 tw:rounded-full tw:text-white tw:text-[13px]/[1.3] tw:font-bold tw:whitespace-nowrap tw:shadow-[0_1px_3px_rgba(0,0,0,0.25)] tw:bg-[#12805C]"
+      >
+        $28
+      </span>
     </div>
     <div
-      class="tw:px-6 tw:pb-2 tw:pt-4"
+      class="tw:p-4"
     >
       <h3
-        class="tw:text-xl tw:text-center tw:font-bold tw:text-[#6255A1] tw:mb-2"
+        class="tw:text-center tw:text-[18px]/[24px] tw:font-bold tw:text-[#6255A1] tw:m-0 tw:line-clamp-2"
       >
         Test Course
       </h3>
       <p
-        class="tw:text-gray-600 tw:text-sm tw:mb-4"
+        class="tw:text-[13px]/[18px] tw:text-[#6B7280] tw:mb-3 tw:line-clamp-2"
       >
         A sample course description.
       </p>
-    </div>
-    <footer
-      class="tw:flex tw:flex-col tw:px-6 tw:pb-6"
-    >
       <div
-        class="tw:flex tw:space-x-2 tw:items-center tw:text-center"
+        class="tw:flex tw:items-center tw:gap-2 tw:mb-2.5 tw:text-[13px] tw:text-[#6B7280]"
       >
-        <div
-          class="tw:flex tw:space-x-1"
+        <span
+          class="tw:flex tw:text-[14px]"
         >
-          <button
-            aria-label="Rate 1 star"
-            class="tw:focus:outline-none tw:bg-transparent"
-            disabled=""
-            style="padding: 0px; background: none; cursor: default;"
-            tabindex="-1"
-            title="1"
-            type="button"
+          <div
+            class="tw:flex tw:space-x-1"
           >
-            <span
-              color="#F8B84E"
-              icon="[object Object]"
-            />
-          </button>
-          <button
-            aria-label="Rate 2 stars"
-            class="tw:focus:outline-none tw:bg-transparent"
-            disabled=""
-            style="padding: 0px; background: none; cursor: default;"
-            tabindex="-1"
-            title="2"
-            type="button"
-          >
-            <span
-              color="#F8B84E"
-              icon="[object Object]"
-            />
-          </button>
-          <button
-            aria-label="Rate 3 stars"
-            class="tw:focus:outline-none tw:bg-transparent"
-            disabled=""
-            style="padding: 0px; background: none; cursor: default;"
-            tabindex="-1"
-            title="3"
-            type="button"
-          >
-            <span
-              color="#F8B84E"
-              icon="[object Object]"
-            />
-          </button>
-          <button
-            aria-label="Rate 4 stars"
-            class="tw:focus:outline-none tw:bg-transparent"
-            disabled=""
-            style="padding: 0px; background: none; cursor: default;"
-            tabindex="-1"
-            title="4"
-            type="button"
-          >
-            <span
-              color="#F8B84E"
-              icon="[object Object]"
-            />
-          </button>
-          <button
-            aria-label="Rate 5 stars"
-            class="tw:focus:outline-none tw:bg-transparent"
-            disabled=""
-            style="padding: 0px; background: none; cursor: default;"
-            tabindex="-1"
-            title="5"
-            type="button"
-          >
-            <span
-              color="#F8B84E"
-              icon="[object Object]"
-            />
-          </button>
-        </div>
-        <span>
+            <button
+              aria-label="Rate 1 star"
+              class="tw:focus:outline-none tw:bg-transparent"
+              disabled=""
+              style="padding: 0px; background: none; cursor: default;"
+              tabindex="-1"
+              title="1"
+              type="button"
+            >
+              <span
+                color="#F5A623"
+                icon="[object Object]"
+              />
+            </button>
+            <button
+              aria-label="Rate 2 stars"
+              class="tw:focus:outline-none tw:bg-transparent"
+              disabled=""
+              style="padding: 0px; background: none; cursor: default;"
+              tabindex="-1"
+              title="2"
+              type="button"
+            >
+              <span
+                color="#F5A623"
+                icon="[object Object]"
+              />
+            </button>
+            <button
+              aria-label="Rate 3 stars"
+              class="tw:focus:outline-none tw:bg-transparent"
+              disabled=""
+              style="padding: 0px; background: none; cursor: default;"
+              tabindex="-1"
+              title="3"
+              type="button"
+            >
+              <span
+                color="#F5A623"
+                icon="[object Object]"
+              />
+            </button>
+            <button
+              aria-label="Rate 4 stars"
+              class="tw:focus:outline-none tw:bg-transparent"
+              disabled=""
+              style="padding: 0px; background: none; cursor: default;"
+              tabindex="-1"
+              title="4"
+              type="button"
+            >
+              <span
+                color="#F5A623"
+                icon="[object Object]"
+              />
+            </button>
+            <button
+              aria-label="Rate 5 stars"
+              class="tw:focus:outline-none tw:bg-transparent"
+              disabled=""
+              style="padding: 0px; background: none; cursor: default;"
+              tabindex="-1"
+              title="5"
+              type="button"
+            >
+              <span
+                color="#F5A623"
+                icon="[object Object]"
+              />
+            </button>
+          </div>
+        </span>
+        <span
+          aria-hidden="true"
+          class="tw:text-[#D1D5DB]"
+        >
           |
         </span>
-        <p
-          class="tw:mb-0"
+        <span
+          class="tw:whitespace-nowrap"
         >
           4.2 Reviews
-        </p>
+        </span>
       </div>
-      <small
-        class="tw:text-grey-neutral"
+      <div
+        class="tw:flex tw:items-center tw:justify-between tw:gap-2 tw:border-t tw:border-[#F3F4F6] tw:pt-2.5"
       >
-        Self-Paced
-      </small>
-    </footer>
-  </div>
+        <span
+          class="tw:text-[12px] tw:text-[#6B7280] tw:bg-[#F3F4F6] tw:rounded tw:px-2 tw:py-0.5 tw:whitespace-nowrap tw:ml-auto"
+        >
+          Self-Paced
+        </span>
+      </div>
+    </div>
+  </a>
 </DocumentFragment>
 `;

--- a/src/components/CourseCard/index.jsx
+++ b/src/components/CourseCard/index.jsx
@@ -1,60 +1,131 @@
+import PropTypes from 'prop-types';
+
+import coursePlaceholder from 'assets/course-placeholder.svg';
+
 import StarRating from '../StarRating';
 
+/**
+ * Swap in the placeholder when a course image fails to load. Studio hands out
+ * a default image path for courses that never had one uploaded, so the URL
+ * looking valid is no guarantee it resolves.
+ */
+export const handleImageError = (event) => {
+  const image = event.currentTarget;
+  // Guard against a loop if the placeholder is what failed.
+  if (image.getAttribute('src') === coursePlaceholder) { return; }
+  image.setAttribute('src', coursePlaceholder);
+};
+
+export const formatStartDate = (startDate) => {
+  if (!startDate) { return null; }
+  const parsed = new Date(startDate);
+  if (Number.isNaN(parsed.getTime())) { return null; }
+  return parsed.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+};
+
+/**
+ * A course card, styled to match the ones on the LMS /courses page — same
+ * badge, cover, centered title, rating row and footer. The two surfaces are
+ * kept deliberately identical, so changes here usually belong in
+ * themes/tutor-indigo/.../sass/courseware/_discover.scss as well.
+ */
 const CourseCard = ({
   courseUrl = '#',
   imageUrl,
   title,
+  orgName,
   description,
   price,
-  rating,
+  isPriced = true,
+  rating = 0,
   selfPaced,
+  startDate,
 }) => {
-  const handleOnClick = () => {
-    window.location.href = courseUrl;
-  };
+  const start = formatStartDate(startDate);
 
   return (
-    <div className="tw:bg-white tw:shadow-md tw:border tw:border-gray-200 tw:rounded-lg tw:overflow-hidden tw:cursor-pointer" onClick={() => handleOnClick()}>
-      <div className="tw:relative tw:w-full tw:h-60">
-        {/* Badge */}
-        <div className="tw:absolute tw:top-3 tw:left-3 tw:bg-[#69AF79] tw:text-white tw:rounded-full tw:w-10 tw:h-10 tw:flex tw:items-center tw:justify-center tw:text-sm tw:font-bold tw-shadow-lg tw:z-10">
-          {price}
-        </div>
+    <a
+      href={courseUrl}
+      className="tw:block tw:no-underline tw:bg-white tw:rounded-[12px] tw:overflow-hidden tw:shadow-[0_1px_3px_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.06)] tw:hover:shadow-[0_4px_12px_rgba(0,0,0,0.12)] tw:hover:-translate-y-0.5 tw:transition tw:duration-200"
+    >
+      <div className="tw:relative tw:w-full tw:h-[170px] tw:overflow-hidden">
+        {/* The cover is genuinely cut on the diagonal rather than tinted, so
+            the wedge shows the card behind it. Same shape on /courses. */}
         <img
-          src={imageUrl}
+          src={imageUrl || coursePlaceholder}
           alt={title}
-          className="tw:w-full tw:h-full tw:object-cover"
+          onError={handleImageError}
+          className="tw:w-full tw:h-full tw:object-cover tw:object-center"
+          style={{ clipPath: 'polygon(0 0, 100% 0, 100% 60%, 0 100%)' }}
         />
-        <div
-          className="tw:absolute tw:inset-0 tw:bg-[#727175] tw:opacity-25"
-          style={{
-            clipPath: "polygon(0 0, 100% 0, 100% 60%, 0 100%)"
-          }}
-        ></div>
+        {/* A pill, not a circle: "₱3,200" has to fit as comfortably as "Free". */}
+        <span
+          className={`tw:absolute tw:top-3 tw:left-3 tw:z-[2] tw:px-3 tw:py-1 tw:rounded-full tw:text-white tw:text-[13px]/[1.3] tw:font-bold tw:whitespace-nowrap tw:shadow-[0_1px_3px_rgba(0,0,0,0.25)] ${isPriced ? 'tw:bg-[#12805C]' : 'tw:bg-[#4B5563]'}`}
+        >
+          {price}
+        </span>
       </div>
-      
-      <div className="tw:px-6 tw:pb-2 tw:pt-4">
-        <h3 className="tw:text-xl tw:text-center tw:font-bold tw:text-[#6255A1] tw:mb-2">
+
+      <div className="tw:p-4">
+        <h3 className="tw:text-center tw:text-[18px]/[24px] tw:font-bold tw:text-[#6255A1] tw:m-0 tw:line-clamp-2">
           {title}
         </h3>
-        <p className="tw:text-gray-600 tw:text-sm tw:mb-4">
-          {description}
-        </p>
-      </div>
-
-      <footer className="tw:flex tw:flex-col tw:px-6 tw:pb-6">
-        <div className='tw:flex tw:space-x-2 tw:items-center tw:text-center'>
-          <StarRating max={5} value={rating} disabled />
-          <span>|</span>
-          <p className='tw:mb-0'>
-            {`${rating} Reviews`}
+        {orgName && (
+          <span className="tw:block tw:text-center tw:text-[13px]/[20px] tw:text-[#70787E] tw:mb-2 tw:truncate">
+            {orgName}
+          </span>
+        )}
+        {/* Courses without a short description set in Studio just show none. */}
+        {description && (
+          <p className="tw:text-[13px]/[18px] tw:text-[#6B7280] tw:mb-3 tw:line-clamp-2">
+            {description}
           </p>
+        )}
+
+        {/* The platform stores no course ratings yet, so this reads 0 until
+            there is something to rate with. It always shows: the row is part
+            of the card's shape, on this surface and on /courses. */}
+        <div className="tw:flex tw:items-center tw:gap-2 tw:mb-2.5 tw:text-[13px] tw:text-[#6B7280]">
+          <span className="tw:flex tw:text-[14px]">
+            <StarRating max={5} value={rating} disabled color="#F5A623" />
+          </span>
+          <span aria-hidden="true" className="tw:text-[#D1D5DB]">|</span>
+          <span className="tw:whitespace-nowrap">{`${rating} Reviews`}</span>
         </div>
 
-        <small className='tw:text-grey-neutral'>{selfPaced ? 'Self-Paced' : 'Instructor-Paced'}</small>
-      </footer>
-    </div>
+        <div className="tw:flex tw:items-center tw:justify-between tw:gap-2 tw:border-t tw:border-[#F3F4F6] tw:pt-2.5">
+          {start && (
+            <span className="tw:inline-flex tw:items-center tw:gap-1.5 tw:text-[13px] tw:text-[#9CA3AF]">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 20 21" fill="none" aria-hidden="true" className="tw:block tw:shrink-0">
+                <path fillRule="evenodd" clipRule="evenodd" d="M15 3.83332H15.8333C16.75 3.83332 17.5 4.58332 17.5 5.49999V17.1667C17.5 18.0833 16.75 18.8333 15.8333 18.8333H4.16667C3.24167 18.8333 2.5 18.0833 2.5 17.1667L2.50833 5.49999C2.50833 4.58332 3.24167 3.83332 4.16667 3.83332H5V2.16666H6.66667V3.83332H13.3333V2.16666H15V3.83332ZM4.16667 8.83332V17.1667H15.8333V8.83332H4.16667ZM15.8333 7.16666H4.16667V5.49999H15.8333V7.16666ZM14.1667 11.3333H10V15.5H14.1667V11.3333Z" fill="#9CA3AF" />
+              </svg>
+              {`Starts: ${start}`}
+            </span>
+          )}
+          <span className="tw:text-[12px] tw:text-[#6B7280] tw:bg-[#F3F4F6] tw:rounded tw:px-2 tw:py-0.5 tw:whitespace-nowrap tw:ml-auto">
+            {selfPaced ? 'Self-Paced' : 'Instructor-Paced'}
+          </span>
+        </div>
+      </div>
+    </a>
   );
-}
+};
+
+CourseCard.propTypes = {
+  courseUrl: PropTypes.string,
+  imageUrl: PropTypes.string,
+  title: PropTypes.string.isRequired,
+  orgName: PropTypes.string,
+  description: PropTypes.string,
+  price: PropTypes.node,
+  isPriced: PropTypes.bool,
+  rating: PropTypes.number,
+  selfPaced: PropTypes.bool,
+  startDate: PropTypes.string,
+};
 
 export default CourseCard;

--- a/src/components/CourseCard/index.test.jsx
+++ b/src/components/CourseCard/index.test.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import coursePlaceholder from 'assets/course-placeholder.svg';
+
 import CourseCard from './index';
 
 // Mock FontAwesomeIcon to avoid rendering issues in StarRating
@@ -16,9 +19,91 @@ describe('CourseCard', () => {
         description="A sample course description."
         price="$28"
         rating={4.2}
-        selfPaced={true}
-      />
+        selfPaced
+      />,
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  // Catalog courses carry no rating, and most carry no short description.
+  it('omits the description but still shows a rating when the course has neither', () => {
+    render(
+      <CourseCard
+        imageUrl="https://example.com/image.png"
+        title="Data Science Essentials"
+        price="₱3,200"
+        selfPaced={false}
+      />,
+    );
+    expect(screen.getByText('Data Science Essentials')).toBeInTheDocument();
+    expect(screen.getByText('₱3,200')).toBeInTheDocument();
+    expect(screen.getByText('Instructor-Paced')).toBeInTheDocument();
+    expect(screen.getByText('0 Reviews')).toBeInTheDocument();
+  });
+
+  it('shows a supplied rating', () => {
+    render(<CourseCard title="Demo" price="Free" rating={4.6} />);
+    expect(screen.getByText('4.6 Reviews')).toBeInTheDocument();
+  });
+
+  it('shows the org, start date and self-paced label', () => {
+    render(
+      <CourseCard
+        title="Demo"
+        orgName="CloudSwyft"
+        price="₱2,500"
+        selfPaced
+        startDate="2026-08-04T06:00:45Z"
+      />,
+    );
+    expect(screen.getByText('CloudSwyft')).toBeInTheDocument();
+    expect(screen.getByText(/^Starts: /)).toBeInTheDocument();
+    expect(screen.getByText('Self-Paced')).toBeInTheDocument();
+  });
+
+  it('omits the start date when the course has none', () => {
+    render(<CourseCard title="Demo" price="Free" />);
+    expect(screen.queryByText(/^Starts: /)).not.toBeInTheDocument();
+  });
+
+  // Matching /courses, where a free course gets the neutral badge and a paid
+  // one gets the green.
+  it('gives paid and free courses different badges', () => {
+    const { rerender } = render(<CourseCard title="Demo" price="₱2,500" isPriced />);
+    expect(screen.getByText('₱2,500').className).toContain('tw:bg-[#12805C]');
+
+    rerender(<CourseCard title="Demo" price="Free" isPriced={false} />);
+    expect(screen.getByText('Free').className).toContain('tw:bg-[#4B5563]');
+  });
+
+  it('links the whole card to the course', () => {
+    render(<CourseCard title="Demo" price="Free" courseUrl="http://lms/courses/x/about" />);
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'http://lms/courses/x/about');
+  });
+
+  describe('course image', () => {
+    it('uses the placeholder when the course has no image', () => {
+      render(<CourseCard title="Data Science Essentials" price="₱3,200" />);
+      expect(screen.getByAltText('Data Science Essentials')).toHaveAttribute('src', coursePlaceholder);
+    });
+
+    it('uses the course image when there is one', () => {
+      render(<CourseCard imageUrl="https://example.com/image.png" title="Demo" price="Free" />);
+      expect(screen.getByAltText('Demo')).toHaveAttribute('src', 'https://example.com/image.png');
+    });
+
+    it('falls back to the placeholder when the image fails to load', () => {
+      render(<CourseCard imageUrl="https://example.com/gone.png" title="Demo" price="Free" />);
+      const image = screen.getByAltText('Demo');
+      fireEvent.error(image);
+      expect(image).toHaveAttribute('src', coursePlaceholder);
+    });
+
+    it('does not loop when the placeholder itself errors', () => {
+      render(<CourseCard title="Demo" price="Free" />);
+      const image = screen.getByAltText('Demo');
+      fireEvent.error(image);
+      expect(image).toHaveAttribute('src', coursePlaceholder);
+    });
   });
 });

--- a/src/containers/CartPage/CartItemRow.jsx
+++ b/src/containers/CartPage/CartItemRow.jsx
@@ -4,14 +4,11 @@ import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Form } from '@openedx/paragon';
 
-import messages from './messages';
+import { formatCurrency } from 'utils';
+import coursePlaceholder from 'assets/course-placeholder.svg';
+import { handleImageError } from 'components/CourseCard';
 
-export const formatCurrency = (amount, currency) => new Intl.NumberFormat('en-PH', {
-  style: 'currency',
-  currency: currency || 'PHP',
-  minimumFractionDigits: 0,
-  maximumFractionDigits: 0,
-}).format(amount);
+import messages from './messages';
 
 export const CartItemRow = ({
   item, isSelected, isPending, onToggle, onRemove,
@@ -38,7 +35,12 @@ export const CartItemRow = ({
       </Form.Checkbox>
 
       <div className="cart-row__card">
-        <img src={item.imageUrl || ''} alt="" className="cart-row__thumb" />
+        <img
+          src={item.imageUrl || coursePlaceholder}
+          alt=""
+          onError={handleImageError}
+          className="cart-row__thumb"
+        />
 
         <div className="cart-row__body">
           <p className="cart-row__title">{item.title}</p>

--- a/src/containers/CartPage/CartSummary.jsx
+++ b/src/containers/CartPage/CartSummary.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Button, Form } from '@openedx/paragon';
 
-import { formatCurrency } from './CartItemRow';
+import { formatCurrency } from 'utils';
 import messages from './messages';
 
 export const CartSummary = ({

--- a/src/containers/CoursesPanel/AnnouncementsList/index.jsx
+++ b/src/containers/CoursesPanel/AnnouncementsList/index.jsx
@@ -158,7 +158,7 @@ const AnnouncementsList = () => {
                 className={`tw:w-8 tw:h-8 tw:rounded tw:text-sm tw:font-semibold tw:cursor-pointer ${
                   currentPage === page
                     ? 'tw:bg-secondary tw:text-white'
-                    : 'tw:bg-transparent tw:text-gray-400 hover:tw:text-secondary'
+                    : 'tw:bg-transparent tw:text-gray-400 tw:hover:text-secondary'
                 }`}
               >
                 {page}

--- a/src/containers/CoursesPanel/CourseStrip/index.jsx
+++ b/src/containers/CoursesPanel/CourseStrip/index.jsx
@@ -1,0 +1,67 @@
+import PropTypes from 'prop-types';
+
+import { formatCurrency } from 'utils';
+
+import CourseCard from 'components/CourseCard';
+
+/**
+ * Shape of a course as /api/learner_home/catalog/ returns it.
+ */
+export const catalogCourseShape = PropTypes.shape({
+  courseId: PropTypes.string.isRequired,
+  courseUrl: PropTypes.string,
+  imageUrl: PropTypes.string,
+  title: PropTypes.string,
+  orgName: PropTypes.string,
+  description: PropTypes.string,
+  price: PropTypes.number,
+  currency: PropTypes.string,
+  isPriced: PropTypes.bool,
+  selfPaced: PropTypes.bool,
+  startDate: PropTypes.string,
+});
+
+/**
+ * A titled four-up row of course cards. Both the "Related" and "Recommended"
+ * strips are this — they differ only in heading and which slice of the catalog
+ * they get, and sharing one component is what keeps them from drifting apart.
+ *
+ * Renders nothing when the slice is empty, rather than leaving a bare heading.
+ */
+const CourseStrip = ({ heading, courses }) => {
+  if (!courses.length) { return null; }
+
+  return (
+    <div className="tw:py-8">
+      <h6 className="tw:text-secondary tw:text-[28px] tw:font-semibold tw:py-4">{heading}</h6>
+
+      <div className="tw:grid tw:grid-cols-1 tw:gap-6 tw:md:grid-cols-4">
+        {courses.map((course) => (
+          <CourseCard
+            key={course.courseId}
+            courseUrl={course.courseUrl}
+            imageUrl={course.imageUrl}
+            title={course.title}
+            orgName={course.orgName}
+            description={course.description}
+            price={course.isPriced ? formatCurrency(course.price, course.currency) : 'Free'}
+            isPriced={course.isPriced}
+            selfPaced={course.selfPaced}
+            startDate={course.startDate}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+CourseStrip.propTypes = {
+  heading: PropTypes.node.isRequired,
+  courses: PropTypes.arrayOf(catalogCourseShape),
+};
+
+CourseStrip.defaultProps = {
+  courses: [],
+};
+
+export default CourseStrip;

--- a/src/containers/CoursesPanel/NoCoursesView/__snapshots__/index.test.jsx.snap
+++ b/src/containers/CoursesPanel/NoCoursesView/__snapshots__/index.test.jsx.snap
@@ -2,26 +2,24 @@
 
 exports[`NoCoursesView snapshot 1`] = `
 <div
-  className="d-flex align-items-center justify-content-center mb-4.5"
-  id="no-courses-content-view"
+  className="tw:flex tw:flex-col tw:items-center tw:justify-center tw:border tw:border-gray-200 tw:rounded-lg tw:py-32 tw:px-6 tw:bg-no-repeat tw:bg-center"
+  style={
+    {
+      "backgroundImage": "url(icon/mock/path)",
+      "backgroundSize": "340px",
+    }
+  }
 >
-  <Image
-    alt="No Courses view banner"
-    src="icon/mock/path"
-  />
-  <h1>
-    Looking for a new challenge?
-  </h1>
-  <p>
-    Explore our courses to add them to your dashboard.
-  </p>
-  <Button
-    as="a"
-    href="http://localhost:18000/course-search-url"
-    iconBefore={[MockFunction icons.Search]}
-    variant="brand"
+  <h2
+    className="tw:text-xl tw:font-bold tw:text-secondary tw:mb-4"
   >
-    Explore courses
-  </Button>
+    Complete First Your Courses
+  </h2>
+  <a
+    className="tw:bg-secondary tw:text-white tw:px-6 tw:py-2 tw:rounded tw:text-sm tw:font-semibold tw:no-underline tw:hover:opacity-90"
+    href="http://localhost:18000/course-search-url"
+  >
+    Explore Courses
+  </a>
 </div>
 `;

--- a/src/containers/CoursesPanel/NoCoursesView/index.jsx
+++ b/src/containers/CoursesPanel/NoCoursesView/index.jsx
@@ -20,7 +20,7 @@ export const NoCoursesView = () => {
       </h2>
       <a
         href={baseAppUrl(courseSearchUrl)}
-        className="tw:bg-secondary tw:text-white tw:px-6 tw:py-2 tw:rounded tw:text-sm tw:font-semibold tw:no-underline hover:tw:opacity-90"
+        className="tw:bg-secondary tw:text-white tw:px-6 tw:py-2 tw:rounded tw:text-sm tw:font-semibold tw:no-underline tw:hover:opacity-90"
       >
         {formatMessage(messages.exploreCoursesButton)}
       </a>

--- a/src/containers/CoursesPanel/RecommendedCoursesList/index.jsx
+++ b/src/containers/CoursesPanel/RecommendedCoursesList/index.jsx
@@ -1,30 +1,28 @@
+import PropTypes from 'prop-types';
+
 import { useIntl } from '@edx/frontend-platform/i18n';
 
+import CourseStrip, { catalogCourseShape } from '../CourseStrip';
 import messages from './messages';
-import CourseCard from '../../../components/CourseCard';
 
-const RecommendedCoursesList = ({  }) => {
+/**
+ * The rest of the catalog the learner isn't enrolled in, straight from
+ * /api/learner_home/catalog/.
+ */
+const RecommendedCoursesList = ({ courses }) => {
   const { formatMessage } = useIntl();
 
   return (
-    <div className="tw:py-8">
-      <h6 className="tw:text-secondary tw:text-[28px] tw:font-semibold tw:py-4">{formatMessage(messages.recommendedCourses)}</h6>
-
-      <div className="tw:grid tw:grid-cols-1 tw:gap-6 tw:md:grid-cols-4">
-        {[...Array(4)].map((_, index) => (
-          <CourseCard
-            key={index}
-            imageUrl={'https://www.dropbox.com/scl/fi/r3cbzqu9xq4z761sjmdtk/datascience.png?rlkey=hd7zl58n47vf874hbnsgjvvzj&st=15gbjx1l&raw=1'}
-            title={'Data Science'}
-            description={'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt.'}
-            price={'$28'}
-            rating={4.6}
-            selfPaced={true}
-          />
-        ))}
-      </div>
-    </div>
+    <CourseStrip heading={formatMessage(messages.recommendedCourses)} courses={courses} />
   );
-}
- 
+};
+
+RecommendedCoursesList.propTypes = {
+  courses: PropTypes.arrayOf(catalogCourseShape),
+};
+
+RecommendedCoursesList.defaultProps = {
+  courses: [],
+};
+
 export default RecommendedCoursesList;

--- a/src/containers/CoursesPanel/RecommendedCoursesList/index.test.jsx
+++ b/src/containers/CoursesPanel/RecommendedCoursesList/index.test.jsx
@@ -2,16 +2,55 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import RecommendedCoursesList from './index';
 
-describe('RecommendedCoursesList', () => {
-	it('renders recommended courses heading', () => {
-		render(<RecommendedCoursesList />);
-		const heading = screen.getByRole('heading', { level: 6 });
-		expect(heading).toBeInTheDocument();
-	});
+const courses = [
+  {
+    courseId: 'course-v1:CloudSwyft+PY101+2026',
+    courseUrl: 'http://localhost:18000/courses/course-v1:CloudSwyft+PY101+2026/about',
+    imageUrl: 'http://localhost:18000/asset-v1:py101.jpg',
+    title: 'Python Programming Fundamentals',
+    orgName: 'CloudSwyft',
+    description: '',
+    startDate: '2026-08-04T06:00:45Z',
+    price: 2500,
+    currency: 'PHP',
+    isPriced: true,
+    selfPaced: false,
+  },
+  {
+    courseId: 'course-v1:CloudSwyft+FREE101+2026',
+    courseUrl: 'http://localhost:18000/courses/course-v1:CloudSwyft+FREE101+2026/about',
+    imageUrl: 'http://localhost:18000/asset-v1:free101.jpg',
+    title: 'Intro to Open Source',
+    orgName: 'CloudSwyft',
+    description: '',
+    startDate: '2026-08-04T06:56:53Z',
+    price: 0,
+    currency: 'PHP',
+    isPriced: false,
+    selfPaced: true,
+  },
+];
 
-	it('renders 4 course cards', () => {
-		render(<RecommendedCoursesList />);
-		const courseCards = screen.getAllByText('Data Science');
-		expect(courseCards).toHaveLength(4);
-	});
+describe('RecommendedCoursesList', () => {
+  it('renders recommended courses heading', () => {
+    render(<RecommendedCoursesList courses={courses} />);
+    expect(screen.getByRole('heading', { level: 6 })).toBeInTheDocument();
+  });
+
+  it('renders a card per course from the catalog', () => {
+    render(<RecommendedCoursesList courses={courses} />);
+    expect(screen.getByText('Python Programming Fundamentals')).toBeInTheDocument();
+    expect(screen.getByText('Intro to Open Source')).toBeInTheDocument();
+  });
+
+  it('prices paid courses and labels free ones', () => {
+    render(<RecommendedCoursesList courses={courses} />);
+    expect(screen.getByText('₱2,500')).toBeInTheDocument();
+    expect(screen.getByText('Free')).toBeInTheDocument();
+  });
+
+  it('renders nothing when the catalog is empty', () => {
+    const { container } = render(<RecommendedCoursesList courses={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
 });

--- a/src/containers/CoursesPanel/RelatedCoursesList/index.jsx
+++ b/src/containers/CoursesPanel/RelatedCoursesList/index.jsx
@@ -1,35 +1,28 @@
+import PropTypes from 'prop-types';
+
 import { useIntl } from '@edx/frontend-platform/i18n';
 
-import React, { useState } from 'react';
-
+import CourseStrip, { catalogCourseShape } from '../CourseStrip';
 import messages from './messages';
-import CourseCard from '../../../components/CourseCard';
 
-const RelatedCoursesList = ({  }) => {
+/**
+ * Courses from organizations the learner already studies with, straight from
+ * /api/learner_home/catalog/.
+ */
+const RelatedCoursesList = ({ courses }) => {
   const { formatMessage } = useIntl();
-  const [hoveredValue, setHoveredValue] = useState(null);
 
   return (
-    <div className="tw:py-8">
-      <h6 className="tw:text-secondary tw:text-[28px] tw:font-semibold tw:py-4">{formatMessage(messages.relatedCourses)}</h6>
-
-      {/* Static Courses */}
-      <div className="tw:grid tw:grid-cols-1 tw:gap-6 tw:md:grid-cols-4">
-        {[...Array(4)].map((_, index) => (
-          <CourseCard
-            key={index}
-            courseUrl={'http://local.openedx.io:8000/courses/course-v1:UCSICollege+INF246x+2022_T1/about'}
-            imageUrl={'https://www.dropbox.com/scl/fi/r3cbzqu9xq4z761sjmdtk/datascience.png?rlkey=hd7zl58n47vf874hbnsgjvvzj&st=15gbjx1l&raw=1'}
-            title={'Data Science'}
-            description={'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt.'}
-            price={'$28'}
-            rating={4.6}
-            selfPaced={true}
-          />
-        ))}
-      </div>
-    </div>
+    <CourseStrip heading={formatMessage(messages.relatedCourses)} courses={courses} />
   );
-}
- 
+};
+
+RelatedCoursesList.propTypes = {
+  courses: PropTypes.arrayOf(catalogCourseShape),
+};
+
+RelatedCoursesList.defaultProps = {
+  courses: [],
+};
+
 export default RelatedCoursesList;

--- a/src/containers/CoursesPanel/RelatedCoursesList/index.test.jsx
+++ b/src/containers/CoursesPanel/RelatedCoursesList/index.test.jsx
@@ -2,16 +2,50 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import RelatedCoursesList from './index';
 
-describe('RelatedCoursesList', () => {
-	it('renders related courses heading', () => {
-		render(<RelatedCoursesList />);
-		const heading = screen.getByRole('heading', { level: 6 });
-		expect(heading).toBeInTheDocument();
-	});
+const courses = [
+  {
+    courseId: 'course-v1:CloudSwyft+DS201+2026',
+    courseUrl: 'http://localhost:18000/courses/course-v1:CloudSwyft+DS201+2026/about',
+    imageUrl: 'http://localhost:18000/asset-v1:ds201.jpg',
+    title: 'Data Science Essentials',
+    orgName: 'CloudSwyft',
+    description: '',
+    startDate: '2026-08-04T06:00:50Z',
+    price: 3200,
+    currency: 'PHP',
+    isPriced: true,
+    selfPaced: false,
+  },
+  {
+    courseId: 'course-v1:CloudSwyft+WEB101+2026',
+    courseUrl: 'http://localhost:18000/courses/course-v1:CloudSwyft+WEB101+2026/about',
+    imageUrl: 'http://localhost:18000/asset-v1:web101.jpg',
+    title: 'Web Development Bootcamp',
+    orgName: 'CloudSwyft',
+    description: '',
+    startDate: '2026-08-04T06:00:57Z',
+    price: 1800,
+    currency: 'PHP',
+    isPriced: true,
+    selfPaced: false,
+  },
+];
 
-	it('renders 4 course cards', () => {
-		render(<RelatedCoursesList />);
-		const courseCards = screen.getAllByText('Data Science');
-		expect(courseCards).toHaveLength(4);
-	});
+describe('RelatedCoursesList', () => {
+  it('renders related courses heading', () => {
+    render(<RelatedCoursesList courses={courses} />);
+    expect(screen.getByRole('heading', { level: 6 })).toBeInTheDocument();
+  });
+
+  it('renders a card per course from the catalog', () => {
+    render(<RelatedCoursesList courses={courses} />);
+    expect(screen.getByText('Data Science Essentials')).toBeInTheDocument();
+    expect(screen.getByText('Web Development Bootcamp')).toBeInTheDocument();
+    expect(screen.getByText('₱3,200')).toBeInTheDocument();
+  });
+
+  it('renders nothing when there are no related courses', () => {
+    const { container } = render(<RelatedCoursesList courses={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
 });

--- a/src/containers/CoursesPanel/__snapshots__/index.test.jsx.snap
+++ b/src/containers/CoursesPanel/__snapshots__/index.test.jsx.snap
@@ -1,55 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CoursesPanel no courses snapshot 1`] = `
-<div
-  className="course-list-container"
->
-  <div
-    className="course-list-heading-container"
-  >
-    <h2
-      className="course-list-title"
-    >
-      My Courses
-    </h2>
-    <div
-      className="course-filter-controls-container"
-    >
-      <CourseFilterControls />
-    </div>
-  </div>
-  <NoCoursesViewSlot />
-</div>
-`;
+exports[`CoursesPanel no courses snapshot 1`] = `undefined`;
 
-exports[`CoursesPanel with courses snapshot 1`] = `
-<div
-  className="course-list-container"
->
-  <div
-    className="course-list-heading-container"
-  >
-    <h2
-      className="course-list-title"
-    >
-      My Courses
-    </h2>
-    <div
-      className="course-filter-controls-container"
-    >
-      <CourseFilterControls />
-    </div>
-  </div>
-  <CourseListSlot
-    courseListData={
-      {
-        "filterOptions": {},
-        "numPages": 1,
-        "setPageNumber": [MockFunction setPageNumber],
-        "showFilters": false,
-        "visibleList": [],
-      }
-    }
-  />
-</div>
-`;
+exports[`CoursesPanel with courses snapshot 1`] = `undefined`;

--- a/src/containers/CoursesPanel/catalogHooks.test.js
+++ b/src/containers/CoursesPanel/catalogHooks.test.js
@@ -1,0 +1,53 @@
+/* eslint-disable import/first, import/no-extraneous-dependencies */
+// useCourseCatalog is a real data-fetching hook, so it needs React's real
+// useState/useEffect rather than the stubs setupTest installs.
+jest.unmock('react');
+
+import { renderHook } from '@testing-library/react-hooks';
+
+import api from 'data/services/lms/api';
+import { useCourseCatalog, emptyCatalog } from './hooks';
+
+jest.mock('data/services/lms/api', () => ({
+  fetchCourseCatalog: jest.fn(),
+}));
+
+// No logging service is configured under test, so the real logError throws.
+jest.mock('@edx/frontend-platform/logging', () => ({
+  logError: jest.fn(),
+}));
+
+const catalog = {
+  related: [{ courseId: 'course-v1:CloudSwyft+DS201+2026' }],
+  recommended: [{ courseId: 'course-v1:CloudSwyft+PY101+2026' }],
+};
+
+describe('useCourseCatalog', () => {
+  beforeEach(() => {
+    api.fetchCourseCatalog.mockReset();
+  });
+
+  it('loads related and recommended courses from the catalog endpoint', async () => {
+    api.fetchCourseCatalog.mockResolvedValue({ data: catalog });
+    const { result, waitForNextUpdate } = renderHook(() => useCourseCatalog());
+    expect(result.current.isLoading).toEqual(true);
+    await waitForNextUpdate();
+    expect(result.current.catalog).toEqual(catalog);
+    expect(result.current.isLoading).toEqual(false);
+  });
+
+  it('defaults missing sections to empty lists', async () => {
+    api.fetchCourseCatalog.mockResolvedValue({ data: {} });
+    const { result, waitForNextUpdate } = renderHook(() => useCourseCatalog());
+    await waitForNextUpdate();
+    expect(result.current.catalog).toEqual(emptyCatalog);
+  });
+
+  it('leaves both lists empty when the request fails', async () => {
+    api.fetchCourseCatalog.mockRejectedValue(new Error('catalog unavailable'));
+    const { result, waitForNextUpdate } = renderHook(() => useCourseCatalog());
+    await waitForNextUpdate();
+    expect(result.current.catalog).toEqual(emptyCatalog);
+    expect(result.current.isLoading).toEqual(false);
+  });
+});

--- a/src/containers/CoursesPanel/hooks.js
+++ b/src/containers/CoursesPanel/hooks.js
@@ -2,7 +2,10 @@ import React from 'react';
 
 import queryString from 'query-string';
 
+import { logError } from '@edx/frontend-platform/logging';
+
 import { ListPageSize, SortKeys } from 'data/constants/app';
+import api from 'data/services/lms/api';
 import { reduxHooks } from 'hooks';
 import { StrictDict } from 'utils';
 
@@ -132,6 +135,45 @@ export const useCompletedCourseListData = () => {
     },
     showFilters: filters.length > 0,
   };
+};
+
+export const emptyCatalog = { related: [], recommended: [] };
+
+/**
+ * Loads the course catalog that backs the "Related" and "Recommended" strips.
+ * One request serves both, so the panel fetches once and hands each strip its
+ * own slice. A failure leaves both lists empty and the strips unrendered — a
+ * suggestion the learner never asked for is not worth an error banner.
+ *
+ * @returns {{catalog: object, isLoading: boolean}}
+ */
+export const useCourseCatalog = () => {
+  const [catalog, setCatalog] = React.useState(emptyCatalog);
+  const [isLoading, setIsLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    api.fetchCourseCatalog()
+      .then(({ data }) => {
+        if (!cancelled) {
+          setCatalog({
+            related: data.related || [],
+            recommended: data.recommended || [],
+          });
+        }
+      })
+      .catch((error) => {
+        logError(error);
+      })
+      .finally(() => {
+        if (!cancelled) { setIsLoading(false); }
+      });
+
+    return () => { cancelled = true; };
+  }, []);
+
+  return { catalog, isLoading };
 };
 
 export default useCourseListData;

--- a/src/containers/CoursesPanel/index.jsx
+++ b/src/containers/CoursesPanel/index.jsx
@@ -6,7 +6,12 @@ import { reduxHooks } from 'hooks';
 import CourseListSlot from 'plugin-slots/CourseListSlot';
 import NoCoursesViewSlot from 'plugin-slots/NoCoursesViewSlot';
 
-import { useCourseListData, useInProgressCourseListData, useCompletedCourseListData } from './hooks';
+import {
+  useCourseListData,
+  useInProgressCourseListData,
+  useCompletedCourseListData,
+  useCourseCatalog,
+} from './hooks';
 import { Container, Tabs, Tab } from '@openedx/paragon';
 
 import myDashboardBg from 'assets/my-dashboard-bg.png';
@@ -28,6 +33,7 @@ export const CoursesPanel = () => {
   const allCoursesData = useCourseListData();
   const inProgressData = useInProgressCourseListData();
   const completedData = useCompletedCourseListData();
+  const { catalog } = useCourseCatalog();
   const [activeTab, setActiveTab] = useState('all');
 
   const activeTabHasCourses = () => {
@@ -106,10 +112,10 @@ export const CoursesPanel = () => {
         </Tabs>
         
         {activeTabHasCourses() && (
-          <RelatedCoursesList />
+          <RelatedCoursesList courses={catalog.related} />
         )}
-        
-        <RecommendedCoursesList />
+
+        <RecommendedCoursesList courses={catalog.recommended} />
 
         {activeTabHasCourses() && (
           <AnnouncementsList />

--- a/src/data/services/lms/api.js
+++ b/src/data/services/lms/api.js
@@ -20,6 +20,8 @@ export const initializeList = ({ user } = {}) => get(
   stringifyUrl(urls.getInitApiUrl(), { [apiKeys.user]: user }),
 );
 
+export const fetchCourseCatalog = () => get(urls.courseCatalogUrl());
+
 export const updateEntitlementEnrollment = ({ uuid, courseId }) => post(
   urls.entitlementEnrollment(uuid),
   { [apiKeys.courseRunId]: courseId },
@@ -95,6 +97,7 @@ export const checkoutCart = ({ courseIds } = {}) => post(
 
 export default {
   initializeList,
+  fetchCourseCatalog,
   unenrollFromCourse,
   updateEmailSettings,
   updateEntitlementEnrollment,

--- a/src/data/services/lms/urls.js
+++ b/src/data/services/lms/urls.js
@@ -9,6 +9,7 @@ const getBaseUrl = () => getConfig().LMS_BASE_URL;
 export const getApiUrl = () => (`${getConfig().LMS_BASE_URL}/api`);
 
 const getInitApiUrl = () => (`${getApiUrl()}/learner_home/init`);
+const courseCatalogUrl = () => `${getApiUrl()}/learner_home/catalog/`;
 
 const event = () => `${getBaseUrl()}/event`;
 const courseUnenroll = () => `${getBaseUrl()}/change_enrollment`;
@@ -42,6 +43,7 @@ export default StrictDict({
   cartItemUrl,
   cartCheckoutUrl,
   cartVerifyUrl,
+  courseCatalogUrl,
   courseUnenroll,
   creditPurchaseUrl,
   creditRequestUrl,

--- a/src/sass/_tailwind.scss
+++ b/src/sass/_tailwind.scss
@@ -1,4 +1,4 @@
-/*! tailwindcss v4.1.7 | MIT License | https://tailwindcss.com */
+/*! tailwindcss v4.1.13 | MIT License | https://tailwindcss.com */
 @layer properties;
 @layer theme, base, components, utilities;
 @layer theme {
@@ -23,10 +23,11 @@
     --tw-font-weight-bold: 700;
     --tw-leading-relaxed: 1.625;
     --tw-radius-lg: 0.5rem;
+    --tw-default-transition-duration: 150ms;
+    --tw-default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     --tw-default-font-family: var(--tw-font-sans);
     --tw-default-mono-font-family: var(--tw-font-mono);
     --tw-color-secondary: #6255A1;
-    --tw-color-grey-neutral: #858585;
   }
 }
 @layer base {
@@ -199,6 +200,12 @@
   .tw\:z-10 {
     z-index: 10 !important;
   }
+  .tw\:z-\[2\] {
+    z-index: 2 !important;
+  }
+  .tw\:m-0 {
+    margin: calc(var(--tw-spacing) * 0) !important;
+  }
   .tw\:my-8 {
     margin-block: calc(var(--tw-spacing) * 8) !important;
   }
@@ -208,14 +215,17 @@
   .tw\:mt-8 {
     margin-top: calc(var(--tw-spacing) * 8) !important;
   }
-  .tw\:mb-0 {
-    margin-bottom: calc(var(--tw-spacing) * 0) !important;
-  }
   .tw\:mb-1 {
     margin-bottom: calc(var(--tw-spacing) * 1) !important;
   }
   .tw\:mb-2 {
     margin-bottom: calc(var(--tw-spacing) * 2) !important;
+  }
+  .tw\:mb-2\.5 {
+    margin-bottom: calc(var(--tw-spacing) * 2.5) !important;
+  }
+  .tw\:mb-3 {
+    margin-bottom: calc(var(--tw-spacing) * 3) !important;
   }
   .tw\:mb-4 {
     margin-bottom: calc(var(--tw-spacing) * 4) !important;
@@ -223,20 +233,32 @@
   .tw\:mb-6 {
     margin-bottom: calc(var(--tw-spacing) * 6) !important;
   }
+  .tw\:ml-auto {
+    margin-left: auto !important;
+  }
+  .tw\:line-clamp-2 {
+    overflow: hidden !important;
+    display: -webkit-box !important;
+    -webkit-box-orient: vertical !important;
+    -webkit-line-clamp: 2 !important;
+  }
+  .tw\:block {
+    display: block !important;
+  }
   .tw\:flex {
     display: flex !important;
   }
   .tw\:grid {
     display: grid !important;
   }
+  .tw\:inline-flex {
+    display: inline-flex !important;
+  }
   .tw\:h-8 {
     height: calc(var(--tw-spacing) * 8) !important;
   }
-  .tw\:h-10 {
-    height: calc(var(--tw-spacing) * 10) !important;
-  }
-  .tw\:h-60 {
-    height: calc(var(--tw-spacing) * 60) !important;
+  .tw\:h-\[170px\] {
+    height: 170px !important;
   }
   .tw\:h-full {
     height: 100% !important;
@@ -244,14 +266,14 @@
   .tw\:w-8 {
     width: calc(var(--tw-spacing) * 8) !important;
   }
-  .tw\:w-10 {
-    width: calc(var(--tw-spacing) * 10) !important;
-  }
   .tw\:w-full {
     width: 100% !important;
   }
   .tw\:min-w-\[160px\] {
     min-width: 160px !important;
+  }
+  .tw\:shrink-0 {
+    flex-shrink: 0 !important;
   }
   .tw\:cursor-pointer {
     cursor: pointer !important;
@@ -265,11 +287,17 @@
   .tw\:items-center {
     align-items: center !important;
   }
+  .tw\:justify-between {
+    justify-content: space-between !important;
+  }
   .tw\:justify-center {
     justify-content: center !important;
   }
   .tw\:justify-end {
     justify-content: flex-end !important;
+  }
+  .tw\:gap-1\.5 {
+    gap: calc(var(--tw-spacing) * 1.5) !important;
   }
   .tw\:gap-2 {
     gap: calc(var(--tw-spacing) * 2) !important;
@@ -284,18 +312,19 @@
       margin-inline-end: calc(calc(var(--tw-spacing) * 1) * calc(1 - var(--tw-space-x-reverse))) !important;
     }
   }
-  .tw\:space-x-2 {
-    :where(& > :not(:last-child)) {
-      --tw-space-x-reverse: 0 !important;
-      margin-inline-start: calc(calc(var(--tw-spacing) * 2) * var(--tw-space-x-reverse)) !important;
-      margin-inline-end: calc(calc(var(--tw-spacing) * 2) * calc(1 - var(--tw-space-x-reverse))) !important;
-    }
+  .tw\:truncate {
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    white-space: nowrap !important;
   }
   .tw\:overflow-hidden {
     overflow: hidden !important;
   }
   .tw\:rounded {
     border-radius: 0.25rem !important;
+  }
+  .tw\:rounded-\[12px\] {
+    border-radius: 12px !important;
   }
   .tw\:rounded-full {
     border-radius: calc(infinity * 1px) !important;
@@ -307,9 +336,16 @@
     border-style: var(--tw-border-style) !important;
     border-width: 1px !important;
   }
+  .tw\:border-t {
+    border-top-style: var(--tw-border-style) !important;
+    border-top-width: 1px !important;
+  }
   .tw\:border-none {
     --tw-border-style: none !important;
     border-style: none !important;
+  }
+  .tw\:border-\[\#F3F4F6\] {
+    border-color: #F3F4F6 !important;
   }
   .tw\:border-gray-200 {
     border-color: var(--tw-color-gray-200) !important;
@@ -317,14 +353,17 @@
   .tw\:border-gray-300 {
     border-color: var(--tw-color-gray-300) !important;
   }
+  .tw\:bg-\[\#4B5563\] {
+    background-color: #4B5563 !important;
+  }
   .tw\:bg-\[\#4EA1C9\] {
     background-color: #4EA1C9 !important;
   }
-  .tw\:bg-\[\#69AF79\] {
-    background-color: #69AF79 !important;
+  .tw\:bg-\[\#12805C\] {
+    background-color: #12805C !important;
   }
-  .tw\:bg-\[\#727175\] {
-    background-color: #727175 !important;
+  .tw\:bg-\[\#F3F4F6\] {
+    background-color: #F3F4F6 !important;
   }
   .tw\:bg-secondary {
     background-color: var(--tw-color-secondary) !important;
@@ -347,11 +386,20 @@
   .tw\:object-cover {
     object-fit: cover !important;
   }
+  .tw\:object-center {
+    object-position: center !important;
+  }
+  .tw\:p-4 {
+    padding: calc(var(--tw-spacing) * 4) !important;
+  }
   .tw\:p-6 {
     padding: calc(var(--tw-spacing) * 6) !important;
   }
   .tw\:px-2 {
     padding-inline: calc(var(--tw-spacing) * 2) !important;
+  }
+  .tw\:px-3 {
+    padding-inline: calc(var(--tw-spacing) * 3) !important;
   }
   .tw\:px-4 {
     padding-inline: calc(var(--tw-spacing) * 4) !important;
@@ -361,6 +409,12 @@
   }
   .tw\:px-8 {
     padding-inline: calc(var(--tw-spacing) * 8) !important;
+  }
+  .tw\:py-0\.5 {
+    padding-block: calc(var(--tw-spacing) * 0.5) !important;
+  }
+  .tw\:py-1 {
+    padding-block: calc(var(--tw-spacing) * 1) !important;
   }
   .tw\:py-2 {
     padding-block: calc(var(--tw-spacing) * 2) !important;
@@ -377,17 +431,27 @@
   .tw\:py-32 {
     padding-block: calc(var(--tw-spacing) * 32) !important;
   }
-  .tw\:pt-4 {
-    padding-top: calc(var(--tw-spacing) * 4) !important;
-  }
-  .tw\:pb-2 {
-    padding-bottom: calc(var(--tw-spacing) * 2) !important;
-  }
-  .tw\:pb-6 {
-    padding-bottom: calc(var(--tw-spacing) * 6) !important;
+  .tw\:pt-2\.5 {
+    padding-top: calc(var(--tw-spacing) * 2.5) !important;
   }
   .tw\:text-center {
     text-align: center !important;
+  }
+  .tw\:text-\[13px\]\/\[1\.3\] {
+    font-size: 13px !important;
+    line-height: 1.3 !important;
+  }
+  .tw\:text-\[13px\]\/\[18px\] {
+    font-size: 13px !important;
+    line-height: 18px !important;
+  }
+  .tw\:text-\[13px\]\/\[20px\] {
+    font-size: 13px !important;
+    line-height: 20px !important;
+  }
+  .tw\:text-\[18px\]\/\[24px\] {
+    font-size: 18px !important;
+    line-height: 24px !important;
   }
   .tw\:text-lg {
     font-size: var(--tw-text-lg) !important;
@@ -400,6 +464,15 @@
   .tw\:text-xl {
     font-size: var(--tw-text-xl) !important;
     line-height: var(--tw-leading, var(--tw-text-xl--line-height)) !important;
+  }
+  .tw\:text-\[12px\] {
+    font-size: 12px !important;
+  }
+  .tw\:text-\[13px\] {
+    font-size: 13px !important;
+  }
+  .tw\:text-\[14px\] {
+    font-size: 14px !important;
   }
   .tw\:text-\[28px\] {
     font-size: 28px !important;
@@ -416,17 +489,29 @@
     --tw-font-weight: var(--tw-font-weight-semibold) !important;
     font-weight: var(--tw-font-weight-semibold) !important;
   }
+  .tw\:whitespace-nowrap {
+    white-space: nowrap !important;
+  }
+  .tw\:text-\[\#6B7280\] {
+    color: #6B7280 !important;
+  }
+  .tw\:text-\[\#9CA3AF\] {
+    color: #9CA3AF !important;
+  }
   .tw\:text-\[\#6255A1\] {
     color: #6255A1 !important;
+  }
+  .tw\:text-\[\#70787E\] {
+    color: #70787E !important;
+  }
+  .tw\:text-\[\#D1D5DB\] {
+    color: #D1D5DB !important;
   }
   .tw\:text-gray-400 {
     color: var(--tw-color-gray-400) !important;
   }
   .tw\:text-gray-600 {
     color: var(--tw-color-gray-600) !important;
-  }
-  .tw\:text-grey-neutral {
-    color: var(--tw-color-grey-neutral) !important;
   }
   .tw\:text-secondary {
     color: var(--tw-color-secondary) !important;
@@ -440,15 +525,55 @@
   .tw\:underline {
     text-decoration-line: underline !important;
   }
-  .tw\:opacity-25 {
-    opacity: 25% !important;
-  }
   .tw\:opacity-\[0\.92\] {
     opacity: 0.92 !important;
   }
-  .tw\:shadow-md {
-    --tw-shadow: 0 4px 6px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 2px 4px -2px var(--tw-shadow-color, rgb(0 0 0 / 0.1)) !important;
+  .tw\:shadow-\[0_1px_3px_rgba\(0\,0\,0\,0\.08\)\,0_1px_2px_rgba\(0\,0\,0\,0\.06\)\] {
+    --tw-shadow: 0 1px 3px var(--tw-shadow-color, rgba(0,0,0,0.08)), 0 1px 2px var(--tw-shadow-color, rgba(0,0,0,0.06)) !important;
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow) !important;
+  }
+  .tw\:shadow-\[0_1px_3px_rgba\(0\,0\,0\,0\.25\)\] {
+    --tw-shadow: 0 1px 3px var(--tw-shadow-color, rgba(0,0,0,0.25)) !important;
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow) !important;
+  }
+  .tw\:transition {
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter, display, content-visibility, overlay, pointer-events !important;
+    transition-timing-function: var(--tw-ease, var(--tw-default-transition-timing-function)) !important;
+    transition-duration: var(--tw-duration, var(--tw-default-transition-duration)) !important;
+  }
+  .tw\:duration-200 {
+    --tw-duration: 200ms !important;
+    transition-duration: 200ms !important;
+  }
+  .tw\:hover\:-translate-y-0\.5 {
+    &:hover {
+      @media (hover: hover) {
+        --tw-translate-y: calc(var(--tw-spacing) * -0.5) !important;
+        translate: var(--tw-translate-x) var(--tw-translate-y) !important;
+      }
+    }
+  }
+  .tw\:hover\:text-secondary {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--tw-color-secondary) !important;
+      }
+    }
+  }
+  .tw\:hover\:opacity-90 {
+    &:hover {
+      @media (hover: hover) {
+        opacity: 90% !important;
+      }
+    }
+  }
+  .tw\:hover\:shadow-\[0_4px_12px_rgba\(0\,0\,0\,0\.12\)\] {
+    &:hover {
+      @media (hover: hover) {
+        --tw-shadow: 0 4px 12px var(--tw-shadow-color, rgba(0,0,0,0.12)) !important;
+        box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow) !important;
+      }
+    }
   }
   .tw\:focus\:outline-none {
     &:focus {
@@ -545,6 +670,25 @@
   inherits: false;
   initial-value: 0 0 #0000;
 }
+@property --tw-duration {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-translate-x {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-translate-y {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-translate-z {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
 @layer properties {
   @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
     *, ::before, ::after, ::backdrop {
@@ -566,6 +710,10 @@
       --tw-ring-offset-width: 0px;
       --tw-ring-offset-color: #fff;
       --tw-ring-offset-shadow: 0 0 #0000;
+      --tw-duration: initial;
+      --tw-translate-x: 0;
+      --tw-translate-y: 0;
+      --tw-translate-z: 0;
     }
   }
 }

--- a/src/test/app.test.jsx
+++ b/src/test/app.test.jsx
@@ -132,6 +132,10 @@ const initCourses = jest.fn(() => []);
 let initializeApp;
 
 const mockApi = () => {
+  // The catalog strips fetch on mount; there is no http client in this harness.
+  api.fetchCourseCatalog = jest.fn(() => Promise.resolve({
+    data: { related: [], recommended: [] },
+  }));
   api.initializeList = jest.fn(() => new Promise(
     (resolve, reject) => {
       resolveFns.init = {

--- a/src/utils/formatCurrency.js
+++ b/src/utils/formatCurrency.js
@@ -1,0 +1,12 @@
+/**
+ * Format a course price the way the cart and the catalog cards both need it.
+ * Prices here are whole pesos, so fractional digits are dropped.
+ */
+export const formatCurrency = (amount, currency) => new Intl.NumberFormat('en-PH', {
+  style: 'currency',
+  currency: currency || 'PHP',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+}).format(amount);
+
+export default formatCurrency;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,3 +3,4 @@ export const nullMethod = () => ({});
 export { default as StrictDict } from './StrictDict';
 export { default as keyStore } from './keyStore';
 export { default as dateFormatter } from './dateFormatter';
+export { default as formatCurrency } from './formatCurrency';


### PR DESCRIPTION
The "Related courses" and "Recommended courses" strips on the dashboard were eight identical hardcoded cards — every one titled *Data Science*, priced `$28`, rated `4.6`, described with lorem ipsum, and illustrated by a Dropbox image. They showed the same thing to every learner regardless of what the platform actually offers. This replaces them with the real catalog from the new `GET /api/learner_home/catalog/` endpoint, and rebuilds the card so it matches the one on the LMS `/courses` page rather than being a third, divergent design.

- **`src/containers/CoursesPanel/hooks.js`** — new `useCourseCatalog()` fetches the catalog once for both strips and hands each its own slice. A failure logs and leaves both lists empty rather than raising a banner: an unrequested suggestion strip is not worth failing the dashboard over.
- **`src/containers/CoursesPanel/CourseStrip/`** — new shared component. `RelatedCoursesList` and `RecommendedCoursesList` were byte-identical apart from their heading, which is exactly the arrangement that lets two things drift; they are now 28-line wrappers over one strip, and each renders nothing when its slice is empty instead of leaving a bare heading.
- **`src/components/CourseCard/index.jsx`** — rebuilt against the `/courses` card spec: 170px cover, centered `#6255A1` title, org line, description, star row, and a footer with start date and pacing chip. The price badge was a fixed 40px circle that squashed `₱1,800` into an oval — it is now a pill that hugs its label, green for paid and neutral for free, matching the LMS. The whole card is a real `<a>` rather than a `div` with an `onClick`, which also cleared its two a11y lint errors.
- **`src/assets/course-placeholder.svg`** — placeholder art for courses with no uploaded image. Studio hands every course a default image path whether or not one exists, so the backend reports `imageUrl: null` and the card falls back; an `onError` handler covers URLs that look valid but 404 at render time, guarded so the placeholder failing cannot loop.
- **`scripts/build-tailwind.mjs` + `npm run build:tailwind`** — this project checks the compiled Tailwind output into the repo rather than building it, so a `tw:` class no source file used before simply does not exist in the CSS. Adding the card's classes without regenerating produced a completely unstyled card that every unit test still passed. The script makes regeneration a documented one-liner.
- **`src/utils/formatCurrency.js`** — moved out of `CartPage/CartItemRow` so the cart and the catalog cards format prices identically.

## Description

The dashboard's two suggestion strips now show the courses this platform actually offers, with real prices, pacing, imagery and links, and the card matches the LMS `/courses` card property for property.

Ratings render as `0 Reviews` with five empty stars. **There is no rating model in the platform** — rather than keep the fabricated `4.6`, the card takes a `rating` prop that defaults to 0, so real ratings need populating, not a rewrite.

**Impact by role**

- **Learner** — sees real, purchasable courses instead of eight copies of a placeholder; accurate prices; placeholder art instead of broken images; each card is keyboard-focusable and opens the course. The cart's course thumbnails also render for the first time (they were pointing at site-relative paths, which resolve against the MFE host and 404).
- **Developer** — **run `npm run build:tailwind` after adding or changing any `tw:` class**, or the class will be missing from `src/sass/_tailwind.scss` and the markup will render unstyled with green tests. Card markup lives in one component; card styling is mirrored in `edx-platform`'s `_discover.scss` and the two are meant to stay in step.
- **Operator** — no new configuration. One extra authenticated GET per dashboard load.

## Supporting information

**Requires the companion `edx-platform` PR**, which adds `GET /api/learner_home/catalog/`. Without it this PR's strips render empty — the fetch 404s, is logged, and both lists stay empty by design. **This PR is not independently useful.**

Trello: `q2GwOelX`.

## Testing instructions

1. Check out the companion `edx-platform` branch first and follow its deployment note (theme files must be copied into the Tutor env; the LMS needs a restart).
2. Check out this branch, `npm install` if needed, and start the MFE. Sign in as a learner and open `http://apps.local.openedx.io:1996/learner-dashboard`.
3. Scroll to "Recommended Courses". It should list the real courses the learner is *not* enrolled in — on this install: Intro to Open Source (**Free**, neutral grey badge), Web Development Bootcamp (**₱1,800**), Data Science Essentials (**₱3,200**), Python Programming Fundamentals (**₱2,500**), all with a green badge except the free one.
4. Confirm the badge is a **pill that fits its text**, not a circle: `₱3,200` must not be clipped or squashed into an oval.
5. Each card should show the org (`CloudSwyft`), a star row reading `0 Reviews`, a start date, and a pacing chip. Click one — it should open that course's about page on the LMS.
6. **Negative test — no enrolled course may appear in the strips.** The learner is enrolled in the Open edX Demo Course, so it must be absent from both strips while appearing under "My Courses" above.
7. **Negative test — no empty headings.** With a learner enrolled in nothing from any org that has other courses, "Related Courses" has no content and the entire section, heading included, must not render. You should never see a heading above blank space.
8. **Negative test — a failing catalog request must not break the page.** Stop the LMS (`tutor dev stop lms`), reload the dashboard: "My Courses" may error as usual, but the two strips must simply be absent, with the failure logged rather than thrown. Restart the LMS.
9. Confirm placeholder art: the four CloudSwyft courses have no uploaded image and should show the purple/blue mortarboard placeholder. Open the cart with a course in it and confirm its thumbnail also renders (previously a broken image).
10. **Regeneration check** — run `npm run build:tailwind` and confirm `git diff src/sass/_tailwind.scss` is empty. The committed CSS must match what the sources generate.
11. `npm test`. Expect **750 passing**; see the coverage note below about the 29 pre-existing failures.

## Deadline

None.

## Other information

- **Migrations** — none; this is a frontend.
- **Security** — no new auth surface. `fetchCourseCatalog` is a plain authenticated GET through the existing `getAuthenticatedHttpClient`, and renders only fields the endpoint returns. No user-supplied HTML is rendered.
- **Test coverage** — new tests cover the catalog hook (success, missing sections, request failure), both strips, and the card (placeholder, image error, error loop guard, badge colour by price, org/date/pacing, link href). `npm test` reports **29 failures, all pre-existing** in `StarRating`, `Dashboard` and the `app` integration suite; I confirmed they are unchanged by diffing failing test *names* against a stash of this branch, not just counting them. That diff caught one real regression this PR introduced — the app integration harness renders the whole dashboard, so the new fetch hit a stubbed-out HTTP client — fixed by stubbing `fetchCourseCatalog` in `mockApi()`.
- **`src/sass/_tailwind.scss` is generated, not hand-edited.** Review the sources and re-run `npm run build:tailwind` rather than reading its 226-line diff. It is committed because the build does not run Tailwind.
- **Drive-by fix — `hover:tw:` never worked.** With `prefix(tw)` the prefix must come first, so the pre-existing `hover:tw:opacity-90` (NoCoursesView) and `hover:tw:text-secondary` (AnnouncementsList) compiled to nothing. Both are now `tw:hover:` and their hover states exist in the CSS for the first time.
- **Snapshots updated.** `CourseCard` and `CoursesPanel` snapshots reflect the new markup. `NoCoursesView`'s snapshot was already stale on `sumac-branch` — failing before this branch — and is regenerated here; its diff is unrelated drift from the earlier dashboard-UI work, not a change made by this PR. The two obsolete strip snapshot files are deleted.
- **Known limitation — duplicated placeholder art.** The same SVG exists in `edx-platform`'s Indigo theme. The MFE bundles its own assets, so referencing the LMS copy would add a cross-origin dependency; the two must be updated together.
- **Known limitation — half stars.** `StarRating` renders half stars where the LMS templates floor to whole ones. Invisible while every rating is 0, but the surfaces will disagree at, say, 4.6.
- **Not verified in a browser.** There is no browser in this environment. Card styling was checked by asserting the compiled CSS declarations against the LMS's, and by confirming the regenerated stylesheet is served in the webpack bundle. A visual pass in Chrome and Safari is worth doing before merge — particularly `clip-path` on the cover image.
