### PR TITLE
[rOuF0DYJ] Course Creation Workflow

### DIFF
--- a/src/containers/LearnerDashboardHeader/LearnerDashboardMenu.jsx
+++ b/src/containers/LearnerDashboardHeader/LearnerDashboardMenu.jsx
@@ -14,6 +14,7 @@ const getLearnerHeaderMenu = (
   exploreCoursesClick,
   cartItemCount = 0,
   isCartPage = false,
+  authoredCourseCount = 0,
 ) => ({
   mainMenu: [
     {
@@ -64,6 +65,14 @@ const getLearnerHeaderMenu = (
     {
       heading: '',
       items: [
+        // Mirrors the LMS navbar dropdown, which leads with Dashboard. Uses
+        // PUBLIC_PATH for the same reason as the main menu: a bare '/' would
+        // leave the router basename and render a blank page.
+        {
+          type: 'item',
+          href: getConfig().PUBLIC_PATH,
+          content: formatMessage(messages.dashboard),
+        },
         {
           type: 'item',
           href: `${getConfig().ACCOUNT_PROFILE_URL}/u/${authenticatedUser?.username}`,
@@ -78,6 +87,13 @@ const getLearnerHeaderMenu = (
           type: 'item',
           href: getConfig().ORDER_HISTORY_URL,
           content: formatMessage(messages.orderHistory),
+        }] : []),
+        // Course authors only. This page lives in the LMS, not in this MFE, so
+        // it needs baseAppUrl rather than the router basename.
+        ...(authoredCourseCount > 0 ? [{
+          type: 'item',
+          href: urls.baseAppUrl('/my-courses'),
+          content: formatMessage(messages.myCourses),
         }] : []),
       ],
     },

--- a/src/containers/LearnerDashboardHeader/hooks.js
+++ b/src/containers/LearnerDashboardHeader/hooks.js
@@ -61,8 +61,34 @@ export const useCartItemCount = () => {
   return count;
 };
 
+/**
+ * useAuthoredCourseCount()
+ * How many courses the viewer authors. Drives whether the header offers a
+ * "My courses" link -- learners who author nothing should never see an
+ * authoring entry point. Failures are swallowed for the same reason as the
+ * cart: this is a nav affordance, not something worth breaking the header for.
+ */
+export const useAuthoredCourseCount = () => {
+  const [count, setCount] = React.useState(0);
+  React.useEffect(() => {
+    let cancelled = false;
+    try {
+      api.fetchAuthoredCourses()
+        .then(({ data }) => {
+          if (!cancelled) { setCount(data.count || 0); }
+        })
+        .catch(() => {});
+    } catch (e) {
+      // An approval-service outage must never break the header.
+    }
+    return () => { cancelled = true; };
+  }, []);
+  return count;
+};
+
 export const useLearnerDashboardHeaderMenu = ({
   courseSearchUrl, authenticatedUser, exploreCoursesClick, cartItemCount = 0, isCartPage = false,
+  authoredCourseCount = 0,
 }) => {
   const { formatMessage } = useIntl();
   return getLearnerHeaderMenu(
@@ -72,6 +98,7 @@ export const useLearnerDashboardHeaderMenu = ({
     exploreCoursesClick,
     cartItemCount,
     isCartPage,
+    authoredCourseCount,
   );
 };
 
@@ -90,6 +117,7 @@ export default {
   findCoursesNavClicked,
   findCoursesNavDropdownClicked,
   useCartItemCount,
+  useAuthoredCourseCount,
   useLearnerDashboardHeaderData,
   useLearnerDashboardHeaderMenu,
 };

--- a/src/containers/LearnerDashboardHeader/index.jsx
+++ b/src/containers/LearnerDashboardHeader/index.jsx
@@ -11,6 +11,7 @@ import ConfirmEmailBanner from './ConfirmEmailBanner';
 import {
   useLearnerDashboardHeaderMenu,
   useCartItemCount,
+  useAuthoredCourseCount,
   findCoursesNavClicked,
   isCartPath,
   DEFAULT_COURSE_SEARCH_URL,
@@ -32,6 +33,7 @@ export const LearnerDashboardHeader = () => {
   };
 
   const cartItemCount = useCartItemCount();
+  const authoredCourseCount = useAuthoredCourseCount();
 
   const learnerHomeHeaderMenu = useLearnerDashboardHeaderMenu({
     courseSearchUrl,
@@ -39,6 +41,7 @@ export const LearnerDashboardHeader = () => {
     exploreCoursesClick,
     cartItemCount,
     isCartPage: isCartPath(),
+    authoredCourseCount,
   });
 
   return (

--- a/src/containers/LearnerDashboardHeader/messages.js
+++ b/src/containers/LearnerDashboardHeader/messages.js
@@ -61,6 +61,16 @@ const messages = defineMessages({
     defaultMessage: 'Discover New',
     description: 'Header link for switching to discover page.',
   },
+  dashboard: {
+    id: 'learnerVariantDashboard.dashboard',
+    defaultMessage: 'Dashboard',
+    description: 'User menu link back to the learner dashboard.',
+  },
+  myCourses: {
+    id: 'learnerVariantDashboard.myCourses',
+    defaultMessage: 'My courses',
+    description: 'User menu link to the course authoring / review page, shown only to course authors.',
+  },
   cart: {
     id: 'learnerVariantDashboard.cart',
     defaultMessage: 'Cart',

--- a/src/data/services/lms/api.js
+++ b/src/data/services/lms/api.js
@@ -88,6 +88,11 @@ export const removeCartItem = ({ courseId }) => client()
 
 export const clearCart = () => client().delete(urls.cartUrl());
 
+/*********************************************************************************
+ * Course approval
+ *********************************************************************************/
+export const fetchAuthoredCourses = () => get(urls.authoredCoursesUrl());
+
 export const verifyCartPayment = () => post(urls.cartVerifyUrl(), {});
 
 export const checkoutCart = ({ courseIds } = {}) => post(
@@ -112,4 +117,5 @@ export default {
   clearCart,
   checkoutCart,
   verifyCartPayment,
+  fetchAuthoredCourses,
 };

--- a/src/data/services/lms/urls.js
+++ b/src/data/services/lms/urls.js
@@ -35,6 +35,10 @@ const cartItemUrl = (courseId) => `${getApiUrl()}/course_cart/items/${courseId}/
 const cartCheckoutUrl = () => `${getApiUrl()}/course_cart/checkout/`;
 const cartVerifyUrl = () => `${getApiUrl()}/course_cart/verify/`;
 
+// Course approval: how many courses this user authors, used to decide whether
+// the header should offer a "My courses" link at all.
+const authoredCoursesUrl = () => `${getApiUrl()}/course-approval/v1/authored/`;
+
 export default StrictDict({
   getApiUrl,
   baseAppUrl,
@@ -43,6 +47,7 @@ export default StrictDict({
   cartItemUrl,
   cartCheckoutUrl,
   cartVerifyUrl,
+  authoredCoursesUrl,
   courseCatalogUrl,
   courseUnenroll,
   creditPurchaseUrl,


### PR DESCRIPTION
Course authoring now has an LMS-side page (`/my-courses`) where authors submit a
course for staff review and propose its price. This MFE renders its own header, so it
cannot pick up the LMS navbar link, leaving the learner dashboard with no route to
that page. This adds the entry, shown only to users who actually author something.

- **`src/data/services/lms/urls.js`, `api.js`** add `fetchAuthoredCourses()`, hitting
  the new `/api/course-approval/v1/authored/` endpoint, which returns `{count, url}`.
- **`src/containers/LearnerDashboardHeader/hooks.js`** adds `useAuthoredCourseCount()`,
  mirroring the existing `useCartItemCount()` including its swallowed failures: this
  is a nav affordance, not something worth breaking the header for.
- **`src/containers/LearnerDashboardHeader/LearnerDashboardMenu.jsx`** adds the
  **My courses** item to the user dropdown, gated on `authoredCourseCount > 0` with the
  same array-spread pattern as the existing `ORDER_HISTORY_URL` item, plus a
  **Dashboard** item so this dropdown matches the LMS one (Dashboard, Profile, Account,
  My courses, sign out). The link uses `baseAppUrl` rather than the router basename,
  because the target page is in the LMS, not this MFE.

## Description

Learners see no change: with no authored courses the request returns `{count: 0}` and
no item is rendered. Authors get a route to the submission page from the dashboard
they already land on after login.

**Impact by role**

- **Learner**: none. One extra authenticated GET per dashboard load.
- **Course Author**: "My courses" appears in the user dropdown.
- **Developer**: no new dependencies; one new service call.
- **Operator**: none. The endpoint is served by the LMS and requires no MFE config.

## Supporting information

Companion PR: the `edx-platform` change that adds the course approval workflow and the
`/api/course-approval/v1/authored/` endpoint. **This PR is not independently useful**
and should not be merged first: without it the request 404s, the count stays 0, and no
menu item ever appears (the header still renders correctly, it just shows nothing new).

## Testing instructions

1. Merge and deploy the `edx-platform` companion PR first, then run this MFE against it.
2. Sign in as a user who authors no courses (a plain learner) and open
   `http://apps.local.openedx.io:1996/learner-dashboard/`. Open the user dropdown: it
   must read Dashboard, Profile, Account, Sign Out, with **no** "My courses" entry.
   This is the negative test.
3. Sign in as a course author (someone holding `instructor`/`staff` on a course, for
   example `banansapientum` on `course-v1:MAPUA+MAPUA-2026+2026_T1`). The same dropdown
   must now include **My courses** between Account and Sign Out.
4. Click it: it must leave the MFE and land on `http://local.openedx.io:8000/my-courses`,
   listing that author's courses.
5. **Failure handling**: stop the LMS (`tutor dev stop lms`) and reload the dashboard.
   The header must still render, simply without the "My courses" item, and no uncaught
   error should reach the console.

## Deadline

None.

## Other information

- **Test coverage**: no tests added. `LearnerDashboardMenu` has an existing snapshot
  test; the snapshot was not regenerated because the new item is conditional and absent
  under the default fixtures. Worth adding: a case with `authoredCourseCount > 0`
  asserting the item renders, and one asserting it does not at `0`.
- **Known limitations**: the count is fetched once on mount and not revalidated, so a
  user granted authoring rights mid-session sees the item only after a reload. The
  request fires on every dashboard load for every user, including learners who will
  never see the item; it is a single small authenticated GET, but it is not free.
- **No lockfile churn**: `package-lock.json` is untouched by this change.
- Labels differ between the two dropdowns: this MFE says "Sign Out", the LMS says
  "Logout". Left alone deliberately, since changing it means editing a `defaultMessage`
  that upstream translations key off.
