### PR TITLE
[TMtVZ62m] Discount Page

### DIFF
--- a/src/containers/CartPage/CartSummary.jsx
+++ b/src/containers/CartPage/CartSummary.jsx
@@ -2,34 +2,96 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { Button, Form } from '@openedx/paragon';
+import { Button, Form, Icon } from '@openedx/paragon';
+import { CheckCircle } from '@openedx/paragon/icons';
 
 import { formatCurrency } from 'utils';
 import messages from './messages';
 
 export const CartSummary = ({
-  count, subtotalCentavos, isCheckingOut, isDisabled, onCheckout,
+  count,
+  subtotalCentavos,
+  discount,
+  discountCentavos,
+  discountError,
+  totalCentavos,
+  isApplyingDiscount,
+  isCheckingOut,
+  isDisabled,
+  onApplyDiscount,
+  onRemoveDiscount,
+  onCheckout,
 }) => {
   const { formatMessage } = useIntl();
+  // The field is uncontrolled until a code sticks: the applied code is shown as
+  // a chip instead, so there is never a stale string sitting in an input next
+  // to a different code in the summary.
+  const [draftCode, setDraftCode] = React.useState('');
+
   const subtotal = subtotalCentavos / 100;
+  const total = totalCentavos / 100;
+  const isFree = totalCentavos === 0 && count > 0;
+  const partialCount = discount ? discount.eligibleCourseIds.length : 0;
+
+  const submitCode = (event) => {
+    event.preventDefault();
+    onApplyDiscount(draftCode);
+  };
+
+  const removeCode = () => {
+    setDraftCode('');
+    onRemoveDiscount();
+  };
 
   return (
     <aside className="cart-summary">
       <h2 className="cart-summary__label">{formatMessage(messages.promotions)}</h2>
-      <div className="cart-summary__coupon">
-        <Form.Control
-          size="sm"
-          disabled
-          placeholder={formatMessage(messages.couponPlaceholder)}
-          aria-label={formatMessage(messages.couponPlaceholder)}
-        />
-        <Button variant="primary" size="sm" disabled>
-          {formatMessage(messages.couponApply)}
-        </Button>
-      </div>
-      <p className="cart-summary__coupon-note">
-        {formatMessage(messages.couponUnavailable)}
-      </p>
+
+      {discount ? (
+        <div className="cart-summary__coupon-applied">
+          <Icon src={CheckCircle} className="cart-summary__coupon-tick" />
+          <div className="cart-summary__coupon-detail">
+            <span className="cart-summary__coupon-code">
+              {formatMessage(messages.couponApplied, { code: discount.code })}
+            </span>
+            {partialCount > 0 && partialCount < count && (
+              <span className="cart-summary__coupon-scope">
+                {formatMessage(messages.couponPartial, { count: partialCount })}
+              </span>
+            )}
+          </div>
+          <Button variant="link" size="sm" onClick={removeCode}>
+            {formatMessage(messages.couponRemove)}
+          </Button>
+        </div>
+      ) : (
+        <form className="cart-summary__coupon" onSubmit={submitCode}>
+          <Form.Control
+            size="sm"
+            value={draftCode}
+            onChange={(event) => setDraftCode(event.target.value)}
+            placeholder={formatMessage(messages.couponPlaceholder)}
+            aria-label={formatMessage(messages.couponPlaceholder)}
+            isInvalid={Boolean(discountError)}
+          />
+          <Button
+            type="submit"
+            variant="primary"
+            size="sm"
+            disabled={isApplyingDiscount || !draftCode.trim() || count === 0}
+          >
+            {isApplyingDiscount
+              ? formatMessage(messages.couponApplying)
+              : formatMessage(messages.couponApply)}
+          </Button>
+        </form>
+      )}
+
+      {discountError ? (
+        <p className="cart-summary__coupon-error" role="alert">{discountError}</p>
+      ) : (
+        <p className="cart-summary__coupon-note">{formatMessage(messages.couponHint)}</p>
+      )}
 
       <div className="cart-summary__panel">
         <h2 className="cart-summary__title">{formatMessage(messages.summary)}</h2>
@@ -40,12 +102,14 @@ export const CartSummary = ({
         </div>
         <div className="cart-summary__line">
           <span>{formatMessage(messages.promo)}</span>
-          <span>0</span>
+          <span className={discountCentavos ? 'cart-summary__discount' : undefined}>
+            {discountCentavos ? `-${formatCurrency(discountCentavos / 100, 'PHP')}` : '0'}
+          </span>
         </div>
 
         <div className="cart-summary__line cart-summary__line--total">
           <span>{formatMessage(messages.total)}</span>
-          <span>{formatCurrency(subtotal, 'PHP')}</span>
+          <span>{formatCurrency(total, 'PHP')}</span>
         </div>
       </div>
 
@@ -55,12 +119,19 @@ export const CartSummary = ({
         disabled={isDisabled}
         onClick={onCheckout}
       >
+        {/* eslint-disable-next-line no-nested-ternary */}
         {isCheckingOut
           ? formatMessage(messages.checkoutPending)
-          : formatMessage(messages.checkout)}
+          : (isFree
+            ? formatMessage(messages.enrollFree)
+            : formatMessage(messages.checkout))}
       </Button>
 
-      <p className="cart-summary__note">{formatMessage(messages.paymentNote)}</p>
+      <p className="cart-summary__note">
+        {isFree
+          ? formatMessage(messages.freeOrderNote)
+          : formatMessage(messages.paymentNote)}
+      </p>
     </aside>
   );
 };
@@ -68,12 +139,26 @@ export const CartSummary = ({
 CartSummary.propTypes = {
   count: PropTypes.number.isRequired,
   subtotalCentavos: PropTypes.number.isRequired,
+  discount: PropTypes.shape({
+    code: PropTypes.string.isRequired,
+    eligibleCourseIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+  }),
+  discountCentavos: PropTypes.number,
+  discountError: PropTypes.string,
+  totalCentavos: PropTypes.number.isRequired,
+  isApplyingDiscount: PropTypes.bool,
   isCheckingOut: PropTypes.bool,
   isDisabled: PropTypes.bool,
+  onApplyDiscount: PropTypes.func.isRequired,
+  onRemoveDiscount: PropTypes.func.isRequired,
   onCheckout: PropTypes.func.isRequired,
 };
 
 CartSummary.defaultProps = {
+  discount: null,
+  discountCentavos: 0,
+  discountError: '',
+  isApplyingDiscount: false,
   isCheckingOut: false,
   isDisabled: false,
 };

--- a/src/containers/CartPage/hooks.js
+++ b/src/containers/CartPage/hooks.js
@@ -29,8 +29,15 @@ export const useCartData = () => {
   const [checkoutError, setCheckoutError] = React.useState(false);
   const [isCheckingOut, setIsCheckingOut] = React.useState(false);
   const [pendingCourseId, setPendingCourseId] = React.useState(null);
-  // Courses enrolled by confirming a payment on return from Paymongo.
+  // Courses enrolled by confirming a payment on return from Paymongo, or by an
+  // order a discount code took to zero.
   const [fulfilledCourses, setFulfilledCourses] = React.useState([]);
+  // The applied discount, as the server priced it. Only one at a time: the
+  // field is replaced, never accumulated.
+  const [discount, setDiscount] = React.useState(null);
+  const [discountCode, setDiscountCode] = React.useState('');
+  const [discountError, setDiscountError] = React.useState('');
+  const [isApplyingDiscount, setIsApplyingDiscount] = React.useState(false);
 
   // Keep every course in the cart selected unless the learner unticks it, and
   // drop ids that are no longer present after a removal.
@@ -56,10 +63,13 @@ export const useCartData = () => {
         }
       });
 
-    // Paymongo returns the learner here with ?payment=success. Confirm the
-    // payment with the backend before loading the cart, so enrollment happens
-    // even if the webhook never arrived.
-    const returnedFromPayment = new URLSearchParams(global.location.search).get('payment') === 'success';
+    // Paymongo returns the learner here either way: ?payment=success after
+    // paying, ?payment=cancelled if they backed out. Both are reconciled with
+    // the backend before the cart loads — success so enrollment happens even
+    // when the webhook never arrived, cancelled so the abandoned order lets go
+    // of the discount code it was holding.
+    const paymentReturn = new URLSearchParams(global.location.search).get('payment');
+    const returnedFromPayment = paymentReturn === 'success' || paymentReturn === 'cancelled';
 
     const start = returnedFromPayment
       ? api.verifyCartPayment()
@@ -95,6 +105,66 @@ export const useCartData = () => {
     ));
   }, []);
 
+  const applyDiscount = React.useCallback((rawCode) => {
+    const code = (rawCode || '').trim();
+    if (!code) { return; }
+    setIsApplyingDiscount(true);
+    setDiscountError('');
+    api.previewCartDiscount({ code, courseIds: selected })
+      .then(({ data }) => {
+        if (data.valid) {
+          setDiscount(data);
+          setDiscountCode(data.code);
+        } else {
+          // An unrecognised or spent code is an expected outcome of typing in
+          // the box, so the server answers 200 with the reason to show.
+          setDiscount(null);
+          setDiscountError(data.error);
+        }
+      })
+      .catch((error) => {
+        logError(error);
+        setDiscount(null);
+        setDiscountError(error?.response?.data?.error || 'That code could not be applied right now.');
+      })
+      .finally(() => setIsApplyingDiscount(false));
+  }, [selected]);
+
+  const removeDiscount = React.useCallback(() => {
+    setDiscount(null);
+    setDiscountCode('');
+    setDiscountError('');
+  }, []);
+
+  // A discount is priced against a specific set of courses, so unticking one
+  // makes the applied figure wrong. Re-quote instead of leaving a stale number
+  // on screen, and drop the code if it no longer covers anything selected.
+  const appliedCode = discount?.code;
+  React.useEffect(() => {
+    if (!appliedCode) { return undefined; }
+    // Nothing selected is not a code problem — the summary is empty anyway, so
+    // drop the discount quietly rather than reporting it as a failure.
+    if (selected.length === 0) { setDiscount(null); return undefined; }
+    let cancelled = false;
+    api.previewCartDiscount({ code: appliedCode, courseIds: selected })
+      .then(({ data }) => {
+        if (cancelled) { return; }
+        if (data.valid) {
+          setDiscount(data);
+        } else {
+          setDiscount(null);
+          setDiscountError(data.error);
+        }
+      })
+      .catch((error) => {
+        if (cancelled) { return; }
+        logError(error);
+        setDiscount(null);
+        setDiscountError('That code no longer applies to what you have selected.');
+      });
+    return () => { cancelled = true; };
+  }, [appliedCode, selected]);
+
   const removeItem = React.useCallback((courseId) => {
     setPendingCourseId(courseId);
     api.removeCartItem({ courseId })
@@ -112,6 +182,9 @@ export const useCartData = () => {
       .then(({ data }) => {
         setCart(data);
         setSelected([]);
+        setDiscount(null);
+        setDiscountCode('');
+        setDiscountError('');
       })
       .catch((error) => {
         logError(error);
@@ -123,26 +196,56 @@ export const useCartData = () => {
   const checkout = React.useCallback(() => {
     setCheckoutError(false);
     setIsCheckingOut(true);
-    api.checkoutCart({ courseIds: selected })
+    api.checkoutCart({ courseIds: selected, discountCode: discount?.code })
       .then(({ data }) => {
+        if (data.fulfilled) {
+          // A code worth the whole order leaves nothing to charge, so the
+          // server enrolled the learner instead of sending them to Paymongo.
+          setFulfilledCourses(data.courses);
+          removeDiscount();
+          setIsCheckingOut(false);
+          return api.fetchCart().then(({ data: refreshed }) => {
+            setCart(refreshed);
+            setSelected(refreshed.items.map(item => item.courseId));
+          });
+        }
         // Leave the button in its pending state; the browser is on its way out.
         window.location.assign(data.checkoutUrl);
+        return undefined;
       })
       .catch((error) => {
         logError(error);
-        setCheckoutError(true);
+        // A code that ran out between preview and checkout is the learner's
+        // problem to fix, not a generic failure, so say which one it was.
+        if (error?.response?.data?.discountRejected) {
+          setDiscount(null);
+          setDiscountError(error.response.data.error);
+        } else {
+          setCheckoutError(true);
+        }
         setIsCheckingOut(false);
       });
-  }, [selected]);
+  }, [selected, discount, removeDiscount]);
 
   const selectedItems = cart.items.filter(item => selected.includes(item.courseId));
   const subtotalCentavos = selectedItems.reduce((sum, item) => sum + item.amountCentavos, 0);
+  const discountCentavos = discount ? discount.discountCentavos : 0;
+  // Clamped rather than trusted: a discount quoted a moment ago against a
+  // larger selection must never render as a negative total while the re-quote
+  // above is still in flight.
+  const totalCentavos = Math.max(subtotalCentavos - discountCentavos, 0);
 
   return {
     cart,
     selected,
     selectedItems,
     subtotalCentavos,
+    discount,
+    discountCode,
+    discountCentavos,
+    discountError,
+    totalCentavos,
+    isApplyingDiscount,
     fulfilledCourses,
     isLoading,
     loadError,
@@ -150,6 +253,8 @@ export const useCartData = () => {
     isCheckingOut,
     pendingCourseId,
     toggleSelected,
+    applyDiscount,
+    removeDiscount,
     removeItem,
     clear,
     checkout,

--- a/src/containers/CartPage/index.jsx
+++ b/src/containers/CartPage/index.jsx
@@ -23,6 +23,11 @@ export const CartPage = () => {
     selected,
     selectedItems,
     subtotalCentavos,
+    discount,
+    discountCentavos,
+    discountError,
+    totalCentavos,
+    isApplyingDiscount,
     fulfilledCourses,
     isLoading,
     loadError,
@@ -30,6 +35,8 @@ export const CartPage = () => {
     isCheckingOut,
     pendingCourseId,
     toggleSelected,
+    applyDiscount,
+    removeDiscount,
     removeItem,
     clear,
     checkout,
@@ -120,8 +127,15 @@ export const CartPage = () => {
                   <CartSummary
                     count={selectedItems.length}
                     subtotalCentavos={subtotalCentavos}
+                    discount={discount}
+                    discountCentavos={discountCentavos}
+                    discountError={discountError}
+                    totalCentavos={totalCentavos}
+                    isApplyingDiscount={isApplyingDiscount}
                     isCheckingOut={isCheckingOut}
                     isDisabled={isBusy || selectedItems.length === 0}
+                    onApplyDiscount={applyDiscount}
+                    onRemoveDiscount={removeDiscount}
                     onCheckout={checkout}
                   />
                 </div>

--- a/src/containers/CartPage/index.scss
+++ b/src/containers/CartPage/index.scss
@@ -197,6 +197,55 @@ $cart-muted: #7a7a8c;
     margin: 0.375rem 0 0;
   }
 
+  // Takes the place of the input once a code sticks, so the applied code and
+  // the figure in the summary can never disagree.
+  &__coupon-applied {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.5rem 0.5rem 0.75rem;
+    border: 1px solid #b7e0c2;
+    border-radius: 0.375rem;
+    background-color: #f0faf3;
+
+    .btn { flex-shrink: 0; }
+  }
+
+  &__coupon-tick {
+    flex: none;
+    color: #178253;
+  }
+
+  &__coupon-detail {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  &__coupon-code {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: #0d4a2f;
+    overflow-wrap: anywhere;
+  }
+
+  &__coupon-scope {
+    font-size: 0.6875rem;
+    color: $cart-muted;
+  }
+
+  &__coupon-error {
+    font-size: 0.75rem;
+    color: #c02020;
+    margin: 0.375rem 0 0;
+  }
+
+  &__discount {
+    color: #178253;
+    font-weight: 600;
+  }
+
   &__panel {
     border: 1px solid $cart-border;
     border-radius: 0.5rem;

--- a/src/containers/CartPage/messages.js
+++ b/src/containers/CartPage/messages.js
@@ -76,10 +76,30 @@ const messages = defineMessages({
     description: 'Button that applies a coupon code',
     defaultMessage: 'Apply',
   },
-  couponUnavailable: {
-    id: 'learner-dash.cart.couponUnavailable',
-    description: 'Note explaining that coupon codes are not enabled',
-    defaultMessage: 'Coupon codes are not enabled yet.',
+  couponHint: {
+    id: 'learner-dash.cart.couponHint',
+    description: 'Note under the coupon field explaining the one-code rule',
+    defaultMessage: 'One code per order. It comes off the courses the code covers.',
+  },
+  couponApplying: {
+    id: 'learner-dash.cart.couponApplying',
+    description: 'Button label while a coupon code is being checked',
+    defaultMessage: 'Checking...',
+  },
+  couponApplied: {
+    id: 'learner-dash.cart.couponApplied',
+    description: 'Confirmation that a coupon code is applied, naming the code',
+    defaultMessage: '{code} applied',
+  },
+  couponRemove: {
+    id: 'learner-dash.cart.couponRemove',
+    description: 'Button that removes the applied coupon code',
+    defaultMessage: 'Remove',
+  },
+  couponPartial: {
+    id: 'learner-dash.cart.couponPartial',
+    description: 'Note when a coupon only covers some of the selected courses',
+    defaultMessage: 'Applies to {count, plural, one {# course} other {# courses}} in your selection.',
   },
   summary: {
     id: 'learner-dash.cart.summary',
@@ -95,6 +115,16 @@ const messages = defineMessages({
     id: 'learner-dash.cart.promo',
     description: 'Promotional discount row in the order summary',
     defaultMessage: 'Promo:',
+  },
+  freeOrderNote: {
+    id: 'learner-dash.cart.freeOrderNote',
+    description: 'Note replacing the payment note when a code covers the whole order',
+    defaultMessage: 'Your code covers the whole order, so there is nothing to pay.',
+  },
+  enrollFree: {
+    id: 'learner-dash.cart.enrollFree',
+    description: 'Checkout button label when a code has taken the total to zero',
+    defaultMessage: 'Complete enrollment',
   },
   total: {
     id: 'learner-dash.cart.total',

--- a/src/containers/LearnerDashboardHeader/LearnerDashboardMenu.jsx
+++ b/src/containers/LearnerDashboardHeader/LearnerDashboardMenu.jsx
@@ -97,6 +97,21 @@ const getLearnerHeaderMenu = (
         }] : []),
       ],
     },
+    // Staff and admins move between the two dashboards all day, and from here
+    // the only way back to /staff was the address bar. Its own group so it
+    // reads as a tool rather than another personal link, and it lives in the
+    // LMS, so baseAppUrl rather than the router basename. `administrator` is
+    // the JWT's spelling of `is_staff`.
+    ...(authenticatedUser?.administrator ? [{
+      heading: '',
+      items: [
+        {
+          type: 'item',
+          href: urls.baseAppUrl('/staff'),
+          content: formatMessage(messages.staffDashboard),
+        },
+      ],
+    }] : []),
     {
       heading: '',
       items: [

--- a/src/containers/LearnerDashboardHeader/LearnerDashboardMenu.test.jsx
+++ b/src/containers/LearnerDashboardHeader/LearnerDashboardMenu.test.jsx
@@ -1,0 +1,37 @@
+import getLearnerHeaderMenu from './LearnerDashboardMenu';
+
+const build = (authenticatedUser) => getLearnerHeaderMenu(
+  (msg) => msg.defaultMessage,
+  '/courses',
+  authenticatedUser,
+  () => {},
+  0,
+  false,
+  0,
+);
+
+const labels = (menu) => menu.userMenu.flatMap(group => group.items.map(item => item.content));
+const hrefs = (menu) => menu.userMenu.flatMap(group => group.items.map(item => item.href));
+
+describe('staff dashboard entry in the user menu', () => {
+  test('staff see it, pointing at the LMS /staff page', () => {
+    const menu = build({ username: 'cloudswyft_staff', administrator: true });
+    expect(labels(menu)).toContain('Staff Dashboard');
+    expect(hrefs(menu).some(href => href && href.endsWith('/staff'))).toBe(true);
+  });
+
+  test('learners do not', () => {
+    expect(labels(build({ username: 'learner', administrator: false }))).not.toContain('Staff Dashboard');
+  });
+
+  test('an unresolved user does not', () => {
+    expect(labels(build(null))).not.toContain('Staff Dashboard');
+  });
+
+  test('it sits above Sign Out and leaves the personal links in order', () => {
+    const menu = build({ username: 'cloudswyft_staff', administrator: true });
+    const all = labels(menu);
+    expect(all.indexOf('Staff Dashboard')).toBeLessThan(all.indexOf('Sign Out'));
+    expect(all.indexOf('Dashboard')).toBeLessThan(all.indexOf('Staff Dashboard'));
+  });
+});

--- a/src/containers/LearnerDashboardHeader/messages.js
+++ b/src/containers/LearnerDashboardHeader/messages.js
@@ -71,6 +71,11 @@ const messages = defineMessages({
     defaultMessage: 'My courses',
     description: 'User menu link to the course authoring / review page, shown only to course authors.',
   },
+  staffDashboard: {
+    id: 'learnerVariantDashboard.staffDashboard',
+    defaultMessage: 'Staff Dashboard',
+    description: 'User menu link to the LMS staff dashboard, shown only to staff.',
+  },
   cart: {
     id: 'learnerVariantDashboard.cart',
     defaultMessage: 'Cart',

--- a/src/data/services/lms/api.js
+++ b/src/data/services/lms/api.js
@@ -95,9 +95,23 @@ export const fetchAuthoredCourses = () => get(urls.authoredCoursesUrl());
 
 export const verifyCartPayment = () => post(urls.cartVerifyUrl(), {});
 
-export const checkoutCart = ({ courseIds } = {}) => post(
+// Prices a code against the current selection without spending a use, so the
+// cart can preview it on every Apply. The code is sent again with the checkout,
+// which re-quotes it server-side rather than trusting the preview.
+export const previewCartDiscount = ({ code, courseIds } = {}) => post(
+  urls.cartDiscountUrl(),
+  {
+    code,
+    ...(courseIds && courseIds.length ? { course_ids: courseIds } : {}),
+  },
+);
+
+export const checkoutCart = ({ courseIds, discountCode } = {}) => post(
   urls.cartCheckoutUrl(),
-  courseIds && courseIds.length ? { course_ids: courseIds } : {},
+  {
+    ...(courseIds && courseIds.length ? { course_ids: courseIds } : {}),
+    ...(discountCode ? { discount_code: discountCode } : {}),
+  },
 );
 
 export default {
@@ -115,6 +129,7 @@ export default {
   addCartItem,
   removeCartItem,
   clearCart,
+  previewCartDiscount,
   checkoutCart,
   verifyCartPayment,
   fetchAuthoredCourses,

--- a/src/data/services/lms/urls.js
+++ b/src/data/services/lms/urls.js
@@ -32,6 +32,7 @@ export const creditRequestUrl = (providerId) => `${getApiUrl()}/credit/v1/provid
 const cartUrl = () => `${getApiUrl()}/course_cart/`;
 const cartItemsUrl = () => `${getApiUrl()}/course_cart/items/`;
 const cartItemUrl = (courseId) => `${getApiUrl()}/course_cart/items/${courseId}/`;
+const cartDiscountUrl = () => `${getApiUrl()}/course_cart/discount/`;
 const cartCheckoutUrl = () => `${getApiUrl()}/course_cart/checkout/`;
 const cartVerifyUrl = () => `${getApiUrl()}/course_cart/verify/`;
 
@@ -45,6 +46,7 @@ export default StrictDict({
   cartUrl,
   cartItemsUrl,
   cartItemUrl,
+  cartDiscountUrl,
   cartCheckoutUrl,
   cartVerifyUrl,
   authoredCoursesUrl,


### PR DESCRIPTION
feat: apply discount codes in the cart, and offer staff a way back to the staff dashboard

The cart's coupon box has been rendered `disabled` since the Paymongo checkout landed, with a "not
available" note under it, because there was no discount API behind it. There is one now, so this
wires the box up: apply a code, see what it takes off, and check out at the discounted price. The
backend half is a companion PR on `edx-platform`.

- **`CartPage/CartSummary.jsx`** replaces the disabled input with a working apply form. Once a code
  sticks it is shown as a chip with the amount off and a Remove button rather than staying in the
  input, so a stale string can never sit next to a different code in the summary. When a code
  covers only part of the selection the chip says how many courses it applies to, and a fully
  discounted order shows a free-enrollment state instead of a price.
- **`CartPage/hooks.js`** holds one discount at a time, priced by the server. Applying calls the
  preview endpoint, which reserves nothing, so the button is free to press repeatedly. **Unticking
  a course re-quotes** rather than leaving a figure on screen that was priced against a larger
  selection, and drops the code if it no longer covers anything. The rendered total is clamped at
  zero so an in-flight re-quote can never paint a negative number.
- **Checkout branches on `fulfilled`** rather than following a URL: a code worth the whole order
  leaves nothing to charge, so the server enrolls directly and answers `checkoutUrl: null`. A code
  that ran out between preview and checkout comes back as `discountRejected`, which is shown against
  the coupon field as the reason it failed rather than as a generic checkout error.
- **The Paymongo return is reconciled on cancel as well as success.** The page now calls
  `verifyCartPayment()` for `?payment=cancelled` too, which is what releases the discount use an
  abandoned checkout was holding, so a learner who backs out can immediately reuse their code.
- **`LearnerDashboardHeader`** gains a **Staff Dashboard** entry in the user dropdown, in its own
  group above Sign Out, pointing at the LMS `/staff`. Gated on the JWT's `administrator` claim, so
  learners never see it. Staff move between the two dashboards constantly and until now the only
  way back was the address bar.

## Description

The learner types a code in the cart summary and presses Apply. The server prices it against the
courses currently ticked and answers with the discount and new total, which the summary renders as
a line between subtotal and total. Checkout sends the code along; the server re-quotes it and
charges the reduced amount.

An unrecognised or spent code comes back as HTTP 200 with a reason, not an error status, and is
shown inline under the field — a mistyped coupon is an expected outcome of using the form.

### Impact by role

- **Learner** — the coupon field works. The applied code survives ticking courses on and off, with
  the figure re-priced each time. A 100% code enrolls without ever reaching a payment page.
  Backing out of Paymongo no longer burns the code.
- **Staff** — a Staff Dashboard link in the user dropdown.
- **Course Author** — none.
- **Operator / Developer** — no new configuration and no new dependencies. Two new API calls,
  `previewCartDiscount` and a `discountCode` argument on `checkoutCart`.

## Supporting information

- Trello: https://trello.com/c/TMtVZ62m/38-discount-page
- **Companion PR: `edx-platform`** — the `course_discounts` app and `POST /api/course_cart/discount/`.
  **This PR is not independently useful:** without that endpoint every Apply fails, so the two must
  go out together.

## Testing instructions

With the companion `edx-platform` branch running and a code `LAUNCH25` created at
`/staff/discounts` (25%, every course, one use per learner):

1. Put two priced courses in the cart at `apps.local.openedx.io:1996/learner-dashboard/cart`.
2. Type `LAUNCH25`, press Apply. Expect the chip to replace the input, a discount line in the
   summary, and the total to fall by 25%.
3. Untick one course. The discount figure must **re-price**, not stay at the old amount.
4. Untick everything. The discount should disappear quietly, with no error shown.
5. Press Remove on the chip. The input comes back empty and the total returns to the subtotal.
6. **Negative test.** Apply `NOPE`. Expect "That discount code was not recognised" inline under the
   field, the input still usable, and no chip.
7. **Partial scope.** With a course-scoped code covering only one of the two courses, apply it and
   confirm the chip says it applies to 1 course.
8. Check out and pay on the Paymongo sandbox. Confirm the amount charged matches the discounted
   total, not the subtotal.
9. **Abandoned checkout.** Apply the code again, press Checkout, then press Back on the Paymongo
   page. You land on the cart with `?payment=cancelled`. Apply the same code again: it must be
   accepted, not rejected as already used.
10. **100% code.** With a code worth the whole order, press Checkout. There should be no redirect;
    the page reports the courses as enrolled and the cart empties.
11. **Staff dropdown.** As a staff user, open the account dropdown top right and confirm **Staff
    Dashboard** appears above Sign Out and opens `local.openedx.io:8000/staff`. As a learner,
    confirm it is absent.

## Deadline

None. Ships with the companion PR.

## Other information

- **Tests.** `LearnerDashboardMenu.test.jsx` is new and covers the dropdown entry in four cases:
  staff see it pointing at `/staff`, learners do not, an unresolved user does not, and it sits above
  Sign Out with the personal links left in order. The menu builder had no test file before this.
  **The cart discount flow has no automated tests** and was verified by hand against the live
  Paymongo sandbox. Worth adding: `applyDiscount` on an invalid code (the 200-with-error path), the
  re-quote effect when `selected` changes, and the `fulfilled` branch in `checkout`.
- **Pre-existing failures in the folder I touched.** `LearnerDashboardHeader/index.test.jsx` has
  four failing tests and a stale snapshot (`wrapper.instance.findByType is not a function`, a
  shallow-renderer API problem in the test itself). Confirmed identical on this branch with my
  changes stashed, so they are not caused by this PR, but CI will be red until someone fixes them.
- **Lint.** `CartPage` and the header changes are clean. eslint does flag a pre-existing duplicate
  `dashboard` key in `LearnerDashboardHeader/messages.js` (lines 4 and 64); both define "Dashboard"
  so behaviour is unaffected and the second wins. Left alone rather than quietly changing a
  translation id, but it is a one-line fix if you want it gone.
- **Known limitations.** One code at a time, matching the backend. A superuser who lacks `is_staff`
  will not see the Staff Dashboard entry even though the page admits them, because the JWT carries
  no `is_superuser` claim.
- **No `package-lock.json` churn** in this branch.
