### PR TITLE
[r74ICX3V] Dashboard Announcement

### DIFF
--- a/src/containers/CoursesPanel/AnnouncementsList/index.jsx
+++ b/src/containers/CoursesPanel/AnnouncementsList/index.jsx
@@ -1,76 +1,70 @@
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+
+import { useAnnouncements } from '../hooks';
 import messages from './messages';
 
+import './index.scss';
+
 const ITEMS_PER_PAGE = 2;
-
-const MOCK_ANNOUNCEMENTS = [
-  {
-    id: 1,
-    title: 'Announcement Title',
-    date: 'Wednesday, 5 October 2022, 10:50 AM',
-    body: 'Nam eu posuere arcu. Nullam neque elit, egestas et dignissim tempus, tincidunt sit amet urna. Integer sem enim, placerat nec lorem nec, molestie lobortis enim. In hac habitasse platea dictumst. Cras dignissim sit amet dui quis ultrices. Phasellus ut congue nisl. Cras ut scelerisque quam. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed placerat sem sit amet sodales fermentum. Quisque erat urna, lacinia non libero nec, posuere sodales neque. Aliquam eget faucibus dui, quis porttitor nunc. Pellentesque a odio consectetur, dignissim diam at, rutrum tortor. Nam luctus elit id erat vehicula consectetur a non erat. Proin porta pulvinar nulla, ac bibendum felis efficitur vitae. Proin at nisi odio. Mauris scelerisque, leo eget mollis blandit, tortor est porttitor purus, at rutrum mi sem in eros.',
-  },
-  {
-    id: 2,
-    title: 'Announcement Title',
-    date: 'Wednesday, 5 October 2022, 10:50 AM',
-    body: 'Nam eu posuere arcu. Nullam neque elit, egestas et dignissim tempus, tincidunt sit amet urna. Integer sem enim, placerat nec lorem nec, molestie lobortis enim. In hac habitasse platea dictumst. Cras dignissim sit amet dui quis ultrices. Phasellus ut congue nisl. Cras ut scelerisque quam. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed placerat sem sit amet sodales fermentum. Quisque erat urna, lacinia non libero nec, posuere sodales neque. Aliquam eget faucibus dui, quis porttitor nunc. Pellentesque a odio consectetur, dignissim diam at, rutrum tortor. Nam luctus elit id erat vehicula consectetur a non erat. Proin porta pulvinar nulla, ac bibendum felis efficitur vitae. Proin at nisi odio. Mauris scelerisque, leo eget mollis blandit, tortor est porttitor purus, at rutrum mi sem in eros.',
-  },
-  {
-    id: 3,
-    title: 'Announcement Title',
-    date: 'Wednesday, 5 October 2022, 10:50 AM',
-    body: 'Nam eu posuere arcu. Nullam neque elit, egestas et dignissim tempus, tincidunt sit amet urna.',
-  },
-  {
-    id: 4,
-    title: 'Announcement Title',
-    date: 'Wednesday, 5 October 2022, 10:50 AM',
-    body: 'Nam eu posuere arcu. Nullam neque elit, egestas et dignissim tempus, tincidunt sit amet urna.',
-  },
-  {
-    id: 5,
-    title: 'Announcement Title',
-    date: 'Wednesday, 5 October 2022, 10:50 AM',
-    body: 'Nam eu posuere arcu. Nullam neque elit, egestas et dignissim tempus, tincidunt sit amet urna.',
-  },
-  {
-    id: 6,
-    title: 'Announcement Title',
-    date: 'Wednesday, 5 October 2022, 10:50 AM',
-    body: 'Nam eu posuere arcu. Nullam neque elit, egestas et dignissim tempus, tincidunt sit amet urna.',
-  },
-  {
-    id: 7,
-    title: 'Announcement Title',
-    date: 'Wednesday, 5 October 2022, 10:50 AM',
-    body: 'Nam eu posuere arcu. Nullam neque elit, egestas et dignissim tempus, tincidunt sit amet urna.',
-  },
-  {
-    id: 8,
-    title: 'Announcement Title',
-    date: 'Wednesday, 5 October 2022, 10:50 AM',
-    body: 'Nam eu posuere arcu. Nullam neque elit, egestas et dignissim tempus, tincidunt sit amet urna.',
-  },
-  {
-    id: 9,
-    title: 'Announcement Title',
-    date: 'Wednesday, 5 October 2022, 10:50 AM',
-    body: 'Nam eu posuere arcu. Nullam neque elit, egestas et dignissim tempus, tincidunt sit amet urna.',
-  },
-];
-
 const MAX_BODY_LENGTH = 400;
 
-const AnnouncementsList = () => {
-  const { formatMessage } = useIntl();
-  const [currentPage, setCurrentPage] = useState(1);
+const ALL = 'all';
 
-  const announcements = MOCK_ANNOUNCEMENTS;
-  const totalPages = Math.ceil(announcements.length / ITEMS_PER_PAGE);
-  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
-  const pageItems = announcements.slice(startIndex, startIndex + ITEMS_PER_PAGE);
+// The model's three levels. The colour that separates them lives in
+// index.scss, keyed off `announcement-card--<level>`; what is needed here is
+// the name for the screen-reader label, since a coloured border says nothing
+// to a reader who cannot see it.
+const LEVEL_LABELS = {
+  info: messages.levelInfo,
+  success: messages.levelSuccess,
+  warning: messages.levelWarning,
+};
+
+export const DATE_RANGES = {
+  [ALL]: null,
+  last7: 7,
+  last30: 30,
+};
+
+/**
+ * Announcements published by staff (`lms.djangoapps.site_announcements`), shown
+ * under the course lists. The endpoint already drops anything inactive,
+ * scheduled or expired, so everything that arrives is displayable and the two
+ * selects below only narrow it further.
+ */
+const AnnouncementsList = () => {
+  const { formatMessage, formatDate } = useIntl();
+  const { announcements, isLoading } = useAnnouncements();
+  const [currentPage, setCurrentPage] = useState(1);
+  const [level, setLevel] = useState(ALL);
+  const [dateRange, setDateRange] = useState(ALL);
+  const [expandedIds, setExpandedIds] = useState([]);
+
+  const visibleAnnouncements = useMemo(() => {
+    const days = DATE_RANGES[dateRange];
+    const cutoff = days === null ? null : Date.now() - (days * 24 * 60 * 60 * 1000);
+    return announcements.filter((announcement) => (
+      (level === ALL || announcement.level === level)
+      && (cutoff === null || announcement.date.getTime() >= cutoff)
+    ));
+  }, [announcements, level, dateRange]);
+
+  const totalPages = Math.ceil(visibleAnnouncements.length / ITEMS_PER_PAGE);
+  // A filter change can leave the list shorter than the page we were on, so
+  // read past the end as the last page rather than rendering an empty one.
+  const page = Math.min(currentPage, Math.max(totalPages, 1));
+  const startIndex = (page - 1) * ITEMS_PER_PAGE;
+  const pageItems = visibleAnnouncements.slice(startIndex, startIndex + ITEMS_PER_PAGE);
+
+  const handleFilterChange = (setter) => (event) => {
+    setter(event.target.value);
+    setCurrentPage(1);
+  };
+
+  const toggleExpanded = (id) => () => setExpandedIds((ids) => (
+    ids.includes(id) ? ids.filter((expandedId) => expandedId !== id) : [...ids, id]
+  ));
 
   const renderPageNumbers = () => {
     const pages = [];
@@ -91,6 +85,12 @@ const AnnouncementsList = () => {
     return pages;
   };
 
+  // Nothing to announce is the normal case, so the whole section stays out of
+  // the page rather than showing an empty shell with dead filters.
+  if (isLoading || announcements.length === 0) {
+    return null;
+  }
+
   return (
     <div className="tw:py-8">
       <h6 className="tw:text-secondary tw:text-[28px] tw:font-semibold tw:py-4">
@@ -99,43 +99,73 @@ const AnnouncementsList = () => {
 
       {/* Filters */}
       <div className="tw:flex tw:gap-6 tw:mb-6">
-        <select className="tw:border tw:border-gray-300 tw:rounded-lg tw:px-4 tw:py-2 tw:text-gray-600 tw:bg-white tw:min-w-[160px]">
-          <option>{formatMessage(messages.fromAll)}</option>
+        <select
+          aria-label={formatMessage(messages.filterLevelLabel)}
+          value={level}
+          onChange={handleFilterChange(setLevel)}
+          className="tw:border tw:border-gray-300 tw:rounded-lg tw:px-4 tw:py-2 tw:text-gray-600 tw:bg-white tw:min-w-[160px]"
+        >
+          <option value={ALL}>{formatMessage(messages.fromAll)}</option>
+          <option value="info">{formatMessage(messages.levelInfo)}</option>
+          <option value="success">{formatMessage(messages.levelSuccess)}</option>
+          <option value="warning">{formatMessage(messages.levelWarning)}</option>
         </select>
-        <select className="tw:border tw:border-gray-300 tw:rounded-lg tw:px-4 tw:py-2 tw:text-gray-600 tw:bg-white tw:min-w-[160px]">
-          <option>{formatMessage(messages.allTime)}</option>
+        <select
+          aria-label={formatMessage(messages.filterDateLabel)}
+          value={dateRange}
+          onChange={handleFilterChange(setDateRange)}
+          className="tw:border tw:border-gray-300 tw:rounded-lg tw:px-4 tw:py-2 tw:text-gray-600 tw:bg-white tw:min-w-[160px]"
+        >
+          <option value={ALL}>{formatMessage(messages.allTime)}</option>
+          <option value="last7">{formatMessage(messages.lastWeek)}</option>
+          <option value="last30">{formatMessage(messages.lastMonth)}</option>
         </select>
       </div>
 
       {/* Announcement Cards */}
       <div className="tw:flex tw:flex-col tw:gap-6">
+        {pageItems.length === 0 && (
+          <p className="tw:text-gray-600 tw:text-sm">{formatMessage(messages.noMatches)}</p>
+        )}
         {pageItems.map((announcement) => {
+          const isExpanded = expandedIds.includes(announcement.id);
           const isTruncated = announcement.body.length > MAX_BODY_LENGTH;
-          const displayBody = isTruncated
+          const displayBody = isTruncated && !isExpanded
             ? `${announcement.body.slice(0, MAX_BODY_LENGTH)}...`
             : announcement.body;
+
+          const levelName = LEVEL_LABELS[announcement.level] ? announcement.level : 'info';
 
           return (
             <div
               key={announcement.id}
-              className="tw:border tw:border-gray-200 tw:rounded-lg tw:p-6"
+              className={`announcement-card announcement-card--${levelName} tw:rounded-lg tw:p-6`}
             >
               <h3 className="tw:text-lg tw:font-bold tw:text-secondary tw:mb-1">
+                <span className="sr-only">{`${formatMessage(LEVEL_LABELS[levelName])}: `}</span>
                 {announcement.title}
               </h3>
               <p className="tw:text-gray-400 tw:text-sm tw:mb-4">
-                {announcement.date}
+                {formatDate(announcement.date, {
+                  weekday: 'long',
+                  day: 'numeric',
+                  month: 'long',
+                  year: 'numeric',
+                  hour: 'numeric',
+                  minute: '2-digit',
+                })}
               </p>
-              <p className="tw:text-gray-600 tw:text-sm tw:leading-relaxed">
+              <p className="tw:text-gray-600 tw:text-sm tw:leading-relaxed tw:whitespace-pre-line">
                 {displayBody}
               </p>
               {isTruncated && (
                 <div className="tw:flex tw:justify-end tw:mt-2">
                   <button
                     type="button"
+                    onClick={toggleExpanded(announcement.id)}
                     className="tw:text-secondary tw:font-bold tw:text-sm tw:underline tw:bg-transparent tw:cursor-pointer"
                   >
-                    {formatMessage(messages.readMore)}
+                    {formatMessage(isExpanded ? messages.readLess : messages.readMore)}
                   </button>
                 </div>
               )}
@@ -147,21 +177,21 @@ const AnnouncementsList = () => {
       {/* Pagination */}
       {totalPages > 1 && (
         <div className="tw:flex tw:justify-center tw:items-center tw:gap-2 tw:mt-8">
-          {renderPageNumbers().map((page, index) => (
-            page === '...' ? (
+          {renderPageNumbers().map((pageNumber, index) => (
+            pageNumber === '...' ? (
               <span key={`ellipsis-${index}`} className="tw:px-2 tw:text-gray-400">…</span>
             ) : (
               <button
-                key={page}
+                key={pageNumber}
                 type="button"
-                onClick={() => setCurrentPage(page)}
+                onClick={() => setCurrentPage(pageNumber)}
                 className={`tw:w-8 tw:h-8 tw:rounded tw:text-sm tw:font-semibold tw:cursor-pointer ${
-                  currentPage === page
+                  page === pageNumber
                     ? 'tw:bg-secondary tw:text-white'
                     : 'tw:bg-transparent tw:text-gray-400 tw:hover:text-secondary'
                 }`}
               >
-                {page}
+                {pageNumber}
               </button>
             )
           ))}

--- a/src/containers/CoursesPanel/AnnouncementsList/index.scss
+++ b/src/containers/CoursesPanel/AnnouncementsList/index.scss
@@ -1,0 +1,17 @@
+// The border is the only thing that tells one announcement level from another,
+// so it is written as real CSS rather than with Tailwind utilities: this MFE
+// imports Tailwind with `important` (src/sass/_input.scss), so a `tw:border`
+// on the card would set border-width on all four sides with !important and
+// flatten the rail — beating even an inline style trying to restore it.
+.announcement-card {
+  border: 1px solid #E1EBF0;
+  border-left: 6px solid #15376D; // info, and the fallback for an unknown level
+}
+
+.announcement-card--success {
+  border-left-color: #1B7F5A;
+}
+
+.announcement-card--warning {
+  border-left-color: #B26A00;
+}

--- a/src/containers/CoursesPanel/AnnouncementsList/messages.js
+++ b/src/containers/CoursesPanel/AnnouncementsList/messages.js
@@ -9,13 +9,49 @@ const messages = defineMessages({
     id: 'dashboard.announcements.fromAll',
     defaultMessage: 'From all',
   },
+  levelInfo: {
+    id: 'dashboard.announcements.levelInfo',
+    defaultMessage: 'Info',
+  },
+  levelSuccess: {
+    id: 'dashboard.announcements.levelSuccess',
+    defaultMessage: 'Success',
+  },
+  levelWarning: {
+    id: 'dashboard.announcements.levelWarning',
+    defaultMessage: 'Warning',
+  },
   allTime: {
     id: 'dashboard.announcements.allTime',
     defaultMessage: 'All time',
   },
+  lastWeek: {
+    id: 'dashboard.announcements.lastWeek',
+    defaultMessage: 'Last 7 days',
+  },
+  lastMonth: {
+    id: 'dashboard.announcements.lastMonth',
+    defaultMessage: 'Last 30 days',
+  },
+  filterLevelLabel: {
+    id: 'dashboard.announcements.filterLevelLabel',
+    defaultMessage: 'Filter announcements by type',
+  },
+  filterDateLabel: {
+    id: 'dashboard.announcements.filterDateLabel',
+    defaultMessage: 'Filter announcements by date',
+  },
+  noMatches: {
+    id: 'dashboard.announcements.noMatches',
+    defaultMessage: 'No announcements match these filters.',
+  },
   readMore: {
     id: 'dashboard.announcements.readMore',
     defaultMessage: 'read more',
+  },
+  readLess: {
+    id: 'dashboard.announcements.readLess',
+    defaultMessage: 'read less',
   },
 });
 

--- a/src/containers/CoursesPanel/announcementHooks.test.js
+++ b/src/containers/CoursesPanel/announcementHooks.test.js
@@ -1,0 +1,58 @@
+/* eslint-disable import/first, import/no-extraneous-dependencies */
+// useAnnouncements is a real data-fetching hook, so it needs React's real
+// useState/useEffect rather than the stubs setupTest installs.
+jest.unmock('react');
+
+import { renderHook } from '@testing-library/react-hooks';
+
+import api from 'data/services/lms/api';
+import { useAnnouncements } from './hooks';
+
+jest.mock('data/services/lms/api', () => ({
+  fetchAnnouncements: jest.fn(),
+}));
+
+// No logging service is configured under test, so the real logError throws.
+jest.mock('@edx/frontend-platform/logging', () => ({
+  logError: jest.fn(),
+}));
+
+const announcement = {
+  id: 3,
+  title: 'Scheduled maintenance',
+  body: 'The site will be briefly unavailable on Sunday.',
+  level: 'warning',
+  date: '2026-08-20T02:30:00+00:00',
+};
+
+describe('useAnnouncements', () => {
+  beforeEach(() => {
+    api.fetchAnnouncements.mockReset();
+  });
+
+  it('loads announcements and parses their dates', async () => {
+    api.fetchAnnouncements.mockResolvedValue({ data: { announcements: [announcement] } });
+    const { result, waitForNextUpdate } = renderHook(() => useAnnouncements());
+    expect(result.current.isLoading).toEqual(true);
+    await waitForNextUpdate();
+    expect(result.current.announcements).toEqual([
+      { ...announcement, date: new Date(announcement.date) },
+    ]);
+    expect(result.current.isLoading).toEqual(false);
+  });
+
+  it('defaults a missing list to an empty one', async () => {
+    api.fetchAnnouncements.mockResolvedValue({ data: {} });
+    const { result, waitForNextUpdate } = renderHook(() => useAnnouncements());
+    await waitForNextUpdate();
+    expect(result.current.announcements).toEqual([]);
+  });
+
+  it('leaves the list empty when the request fails', async () => {
+    api.fetchAnnouncements.mockRejectedValue(new Error('announcements unavailable'));
+    const { result, waitForNextUpdate } = renderHook(() => useAnnouncements());
+    await waitForNextUpdate();
+    expect(result.current.announcements).toEqual([]);
+    expect(result.current.isLoading).toEqual(false);
+  });
+});

--- a/src/containers/CoursesPanel/hooks.js
+++ b/src/containers/CoursesPanel/hooks.js
@@ -176,4 +176,47 @@ export const useCourseCatalog = () => {
   return { catalog, isLoading };
 };
 
+/**
+ * Loads the site announcements shown under the course lists.
+ *
+ * The endpoint only answers signed-in callers and already applies the
+ * active/starts_at/ends_at window, so whatever comes back is what the learner
+ * should see; the component only paginates and filters it. A failure leaves the
+ * list empty and the section unrendered — a notice we could not fetch is not
+ * worth an error banner on the dashboard.
+ *
+ * `date` arrives as an ISO string and is parsed here so every consumer sorts
+ * and formats the same Date rather than re-parsing the string.
+ *
+ * @returns {{announcements: object[], isLoading: boolean}}
+ */
+export const useAnnouncements = () => {
+  const [announcements, setAnnouncements] = React.useState([]);
+  const [isLoading, setIsLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    api.fetchAnnouncements()
+      .then(({ data }) => {
+        if (!cancelled) {
+          setAnnouncements((data.announcements || []).map((announcement) => ({
+            ...announcement,
+            date: new Date(announcement.date),
+          })));
+        }
+      })
+      .catch((error) => {
+        logError(error);
+      })
+      .finally(() => {
+        if (!cancelled) { setIsLoading(false); }
+      });
+
+    return () => { cancelled = true; };
+  }, []);
+
+  return { announcements, isLoading };
+};
+
 export default useCourseListData;

--- a/src/data/services/lms/api.js
+++ b/src/data/services/lms/api.js
@@ -22,6 +22,8 @@ export const initializeList = ({ user } = {}) => get(
 
 export const fetchCourseCatalog = () => get(urls.courseCatalogUrl());
 
+export const fetchAnnouncements = () => get(urls.announcementsUrl());
+
 export const updateEntitlementEnrollment = ({ uuid, courseId }) => post(
   urls.entitlementEnrollment(uuid),
   { [apiKeys.courseRunId]: courseId },
@@ -117,6 +119,7 @@ export const checkoutCart = ({ courseIds, discountCode } = {}) => post(
 export default {
   initializeList,
   fetchCourseCatalog,
+  fetchAnnouncements,
   unenrollFromCourse,
   updateEmailSettings,
   updateEntitlementEnrollment,

--- a/src/data/services/lms/urls.js
+++ b/src/data/services/lms/urls.js
@@ -10,6 +10,7 @@ export const getApiUrl = () => (`${getConfig().LMS_BASE_URL}/api`);
 
 const getInitApiUrl = () => (`${getApiUrl()}/learner_home/init`);
 const courseCatalogUrl = () => `${getApiUrl()}/learner_home/catalog/`;
+const announcementsUrl = () => `${getApiUrl()}/announcements/`;
 
 const event = () => `${getBaseUrl()}/event`;
 const courseUnenroll = () => `${getBaseUrl()}/change_enrollment`;
@@ -42,6 +43,7 @@ const authoredCoursesUrl = () => `${getApiUrl()}/course-approval/v1/authored/`;
 
 export default StrictDict({
   getApiUrl,
+  announcementsUrl,
   baseAppUrl,
   cartUrl,
   cartItemsUrl,


### PR DESCRIPTION
The Announcements section on the learner dashboard rendered `MOCK_ANNOUNCEMENTS` — nine hardcoded
lorem entries all titled "Announcement Title" and dated 5 October 2022 — so every learner saw the
same placeholder text no matter what staff published at `/staff/announcements`. Its two filter
selects and its "read more" button were decorative: neither was wired to anything. This points the
section at `GET /api/announcements/` and makes those controls do what they say.

- **`src/data/services/lms/urls.js` / `api.js`** — adds `announcementsUrl` and
  `fetchAnnouncements`, following the same shape as the existing `courseCatalogUrl` /
  `fetchCourseCatalog` pair, so the endpoint is resolved from `LMS_BASE_URL` like every other call.
- **`src/containers/CoursesPanel/hooks.js`** — new `useAnnouncements`, deliberately mirroring
  `useCourseCatalog`: fetch once on mount, `logError` a failure, and leave the list empty rather
  than raising a banner — a notice we could not fetch is not worth breaking the dashboard over. It
  parses the ISO `date` into a `Date` once, so consumers never re-parse the string.
- **`src/containers/CoursesPanel/AnnouncementsList/index.jsx`** — mock removed. The section returns
  `null` while loading and when there is nothing to show, so an empty announcement list leaves no
  empty shell with dead filters behind. The two selects now filter by `level` and by a 7/30-day
  window and reset to page 1 on change; pagination clamps rather than stranding you on a page the
  filtered list no longer has; "read more" expands and collapses; the date is rendered through
  `formatDate` instead of a baked-in string.
- **`src/containers/CoursesPanel/AnnouncementsList/index.scss`** (new) — a per-level left border,
  6px, navy `#15376D` info / green `#1B7F5A` success / amber `#B26A00` warning. This is real CSS
  rather than Tailwind utilities on purpose: this app imports Tailwind with `important`
  (`src/sass/_input.scss`), so a `tw:border` on the card sets `border-width` on all four sides with
  `!important` and flattens the rail — it beats even an inline style. Writing it as CSS also gets
  the RTL mirror for free from the existing postcss plugin.
- **`src/containers/CoursesPanel/announcementHooks.test.js`** (new) — covers the loaded-and-parsed
  case, a response with no `announcements` key, and a rejected request.

## Description

The dashboard now shows the announcements staff actually published, newest first, two per page.
The server has already dropped anything inactive, scheduled or expired, so everything that arrives
is displayable. Level is conveyed by the card's left border plus an `sr-only` prefix on the title
("Warning: Scheduled maintenance"), so it is not colour-only for a screen reader.

**Impact by role**

- **Learner** — sees real announcements instead of lorem ipsum, can filter them by type and recency,
  and can expand a long one. When there is nothing to show, the section is absent rather than empty.
- **Developer** — `useAnnouncements` is available from `CoursesPanel/hooks`. Note the Tailwind
  `important` behaviour documented in the new SCSS file before reaching for `tw:border-*` on
  anything whose border matters.
- **Operator** — requires the companion `edx-platform` PR to be deployed, otherwise the request is
  answered with a redirect and the section stays hidden. No new environment configuration; the URL
  is derived from the existing `LMS_BASE_URL`.

## Supporting information

- Companion PR: `edx-platform` — *"Serve announcements through a DRF view so the learner dashboard
  can fetch them"*. **This PR is not independently useful**: without it the endpoint answers an
  anonymous 302 that the fetch cannot follow, so the section renders nothing. Merge both or neither.
- Announcements are authored by staff at `http://local.openedx.io:8000/staff/announcements`.

## Testing instructions

1. Deploy the companion `edx-platform` PR and `tutor dev restart lms`.
2. As a staff user, create three announcements at `/staff/announcements`:
   - "Scheduled maintenance", level **Warning**, body over 400 characters
   - "Enrollment open", level **Success**, short body
   - "Welcome back", level **Info**, short body, `starts_at` backdated 20 days
3. As a learner **enrolled in at least one course**, open
   `http://apps.local.openedx.io:1996/learner-dashboard/` and scroll to Announcements. Expect the
   two newest, newest first, each with a coloured left border matching its level — amber, green,
   navy — and page 2 holding the third.
4. On "Scheduled maintenance", click **read more**: the full body expands and the link becomes
   **read less**, which collapses it again.
5. Set the first select to **Warning**: only "Scheduled maintenance" remains and pagination
   disappears. Set it to **Info** while the second select is **Last 7 days**. **Negative test:**
   "Welcome back" is 20 days old, so nothing matches — you must get
   "No announcements match these filters.", not a blank card or a stranded empty page 2.
6. **Repeat-action test:** page to 2, then change a filter. You must land back on page 1 with
   results visible, never on an empty page.
7. **Negative test:** open the dashboard URL in a private window while signed out. The page must
   redirect to login as usual, with no console error from the announcements fetch and no
   announcement content exposed.
8. Deactivate every announcement in `/staff/announcements` and reload. The Announcements heading and
   both selects must be gone entirely, not present above an empty list.

## Deadline

None.

## Other information

- **Test coverage** — `useAnnouncements` has three unit tests. The **component itself has no test**;
  worth adding: the level filter, the date-window filter, the read more / read less toggle, and
  that the section renders `null` when the list is empty. `npx jest src/containers/CoursesPanel`
  passes (8 suites, 31 tests). Note the repo has 5 pre-existing failing suites on
  `sumac-branch` (StarRating, Dashboard, DashboardLayout, LearnerDashboardHeader, app) that are
  unrelated to this change — confirmed by stashing these edits and re-running.
- **Known limitations** — `CoursesPanel/index.jsx` still only mounts `AnnouncementsList` when the
  active tab has courses, so a learner with no enrollments never sees announcements. That is
  pre-existing placement, left alone here, and is a one-line change if it should be unconditional.
  Filtering and pagination are client side over at most the 20 rows the API returns, so a site
  with heavy announcement traffic would need server-side paging. There is no read or dismissed
  state, so an announcement looks the same on every visit.
- **Styling constraint worth knowing** — Tailwind is imported with `important` in this app. Any
  border, and anything else you might reasonably try to override inline, has to be written as real
  CSS. The first attempt at this rail used `tw:border-l-4` plus an inline colour and rendered as a
  plain grey card.
- **No lockfile churn** — `package-lock.json` is untouched.
- **Branching** — this is `feature/trello-r74ICX3V-announcement-integration` against
  `sumac-branch`. The platform side is `feature/trello-r74ICX3V-announcement` against `main`.